### PR TITLE
[#56] Add schemaVersion field to Channel

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -47,6 +47,11 @@ public class Channel implements AutoCloseable {
     private static final String CLASSIFIER="channel";
     private static final String EXTENSION="yaml";
 
+    /** Version of the schema used by this channel.
+     * This is a required field.
+     */
+    private final String schemaVersion;
+
     /**
      * Name of the channel (as an one-line human readable description of the channel).
      * This is an optional field.
@@ -83,12 +88,14 @@ public class Channel implements AutoCloseable {
 
     private MavenVersionsResolver resolver;
 
-    public Channel(@JsonProperty(value = "name") String name,
+    public Channel(@JsonProperty(value = "schemaVersion", required = true) String schemaVersion,
+                   @JsonProperty(value = "name") String name,
                    @JsonProperty(value = "description") String description,
                    @JsonProperty(value = "vendor") Vendor vendor,
                    @JsonProperty(value = "requires")
                    @JsonInclude(NON_EMPTY) List<ChannelRequirement> channelRequirements,
                    @JsonProperty(value = "streams") Collection<Stream> streams) {
+        this.schemaVersion = schemaVersion;
         this.name = name;
         this.description = description;
         this.vendor = vendor;
@@ -97,6 +104,11 @@ public class Channel implements AutoCloseable {
         if (streams != null) {
             this.streams.addAll(streams);
         }
+    }
+
+    @JsonInclude
+    public String getSchemaVersion() {
+        return schemaVersion;
     }
 
     @JsonInclude(NON_NULL)

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -25,7 +25,9 @@ import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,12 +48,32 @@ import com.networknt.schema.ValidationMessage;
  */
 public class ChannelMapper {
 
-    private static final String SCHEMA_FILE = "org/wildfly/channel/channel-schema.json";
+    public static final String SCHEMA_VERSION_1_0_0 = "1.0.0";
+    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_0;
+
+    private static final String SCHEMA_1_0_0_FILE = "org/wildfly/channel/v1.0.0/schema.json";
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
             .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
-    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).objectMapper(OBJECT_MAPPER).build();
-    private static final JsonSchema SCHEMA = SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_FILE));
+    private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).objectMapper(OBJECT_MAPPER).build();
+    private static final Map<String, JsonSchema> SCHEMAS = new HashMap<>();
+
+    static {
+        SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
+    }
+
+    private static JsonSchema getSchema(JsonNode node) {
+        JsonNode schemaVersion = node.path("schemaVersion");
+        String version = schemaVersion.asText();
+        if (version == null || version.isEmpty()) {
+            throw new RuntimeException("The channel does not specify a schemaVersion.");
+        }
+        JsonSchema schema = SCHEMAS.get(version);
+        if (schema == null) {
+            throw new RuntimeException("Unknown schema version " + schemaVersion);
+        }
+        return schema;
+    }
 
     public static String toYaml(Channel... channels) throws IOException {
         return toYaml(Arrays.asList(channels));
@@ -105,13 +127,15 @@ public class ChannelMapper {
 
     private static List<String> validate(URL url) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(url);
-        Set<ValidationMessage> validationMessages = SCHEMA.validate(node);
+        JsonSchema schema = getSchema(node);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
         return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
     }
 
     private static List<String> validateString(String yamlContent) throws IOException {
         JsonNode node = OBJECT_MAPPER.readTree(yamlContent);
-        Set<ValidationMessage> validationMessages = SCHEMA.validate(node);
+        JsonSchema schema = getSchema(node);
+        Set<ValidationMessage> validationMessages = schema.validate(node);
         return validationMessages.stream().map(ValidationMessage::getMessage).collect(Collectors.toList());
     }
 

--- a/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
@@ -20,7 +20,8 @@ import java.util.Collections;
 
 class ChannelRecorder {
 
-    final Channel recordedChannel = new Channel(null,
+    final Channel recordedChannel = new Channel(ChannelMapper.CURRENT_SCHEMA_VERSION,
+            null,
             null,
             null,
             null,

--- a/core/src/main/resources/org/wildfly/channel/v1.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/channel/v1.0.0/schema.json
@@ -1,8 +1,14 @@
 {
-  "$id": "https://wildfly.org/channel.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://wildfly.org/channels/v1.0.0/schema.json",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
   "type": "object",
+  "required": ["schemaVersion"],
   "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a channel resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
     "name": {
       "description": "Name of the channel. This is a one-line human-readable description of the channel",
       "type": "string"

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -16,19 +16,20 @@
  */
 package org.wildfly.channel;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
+
 import java.net.URL;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 public class ChannelMapperTestCase {
 
     @Test
     public void testWriteReadChannel() throws Exception {
-        final Channel channel = new Channel("test_name", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final Channel channel = new Channel(CURRENT_SCHEMA_VERSION,"test_name", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
         final String yaml = ChannelMapper.toYaml(channel);
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);

--- a/core/src/test/java/org/wildfly/channel/ChannelRecorderTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelRecorderTestCase.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,6 +43,7 @@ public class ChannelRecorderTestCase {
     public void testChannelRecorder() throws IOException, UnresolvedMavenArtifactException {
 
         List<Channel> channels = ChannelMapper.fromString("---\n" +
+                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "streams:\n" +
                 "  - groupId: org.wildfly\n" +
                 "    artifactId: '*'\n" +
@@ -53,6 +55,7 @@ public class ChannelRecorderTestCase {
                 "    artifactId: '*'\n" +
                 "    versionPattern: '2\\.\\1\\.\\d+.Final'\n" +
                 "---\n" +
+                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "streams:\n" +
                 "  - groupId: io.undertow\n" +
                 "    artifactId: '*'\n" +

--- a/core/src/test/java/org/wildfly/channel/ChannelSessionTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelSessionTestCase.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.io.File;
 import java.util.List;
@@ -40,7 +41,9 @@ public class ChannelSessionTestCase {
 
     @Test
     public void testFindLatestMavenArtifactVersion() throws UnresolvedMavenArtifactException {
-        List<Channel> channels = ChannelMapper.fromString("streams:\n" +
+        List<Channel> channels = ChannelMapper.fromString(
+                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
                 "  - groupId: org.wildfly\n" +
                 "    artifactId: '*'\n" +
                 "    versionPattern: '25\\.\\d+\\.\\d+.Final'");
@@ -63,7 +66,8 @@ public class ChannelSessionTestCase {
 
     @Test
     public void testFindLatestMavenArtifactVersionThrowsUnresolvedMavenArtifactException() throws UnresolvedMavenArtifactException {
-        List<Channel> channels = ChannelMapper.fromString("streams:\n" +
+        List<Channel> channels = ChannelMapper.fromString(                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
                 "  - groupId: org.wildfly\n" +
                 "    artifactId: '*'\n" +
                 "    versionPattern: '25\\.\\d+\\.\\d+.Final'");
@@ -90,7 +94,8 @@ public class ChannelSessionTestCase {
 
     @Test
     public void testResolveLatestMavenArtifact() throws UnresolvedMavenArtifactException {
-        List<Channel> channels = ChannelMapper.fromString("streams:\n" +
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
                 "  - groupId: org.wildfly\n" +
                 "    artifactId: '*'\n" +
                 "    versionPattern: '25\\.\\d+\\.\\d+.Final'");
@@ -123,7 +128,9 @@ public class ChannelSessionTestCase {
 
     @Test
     public void testResolveLatestMavenArtifactThrowUnresolvedMavenArtifactException() {
-        List<Channel> channels = ChannelMapper.fromString("streams:\n" +
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "schemaVersion: 1.0.0\n" +
+                "streams:\n" +
                 "  - groupId: org.wildfly\n" +
                 "    artifactId: '*'\n" +
                 "    versionPattern: '25\\.\\d+\\.\\d+.Final'");
@@ -150,7 +157,8 @@ public class ChannelSessionTestCase {
 
     @Test
     public void testResolveDirectMavenArtifact() throws UnresolvedMavenArtifactException {
-        List<Channel> channels = ChannelMapper.fromString("streams:\n" +
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
                 "  - groupId: org.foo\n" +
                 "    artifactId: foo\n" +
                 "    version: \"25.0.0.Final\"");

--- a/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -58,11 +59,11 @@ public class ChannelWithRequirementsTestCase {
         when(resolver.resolveArtifact("org.example", "foo-bar", null, null, "1.2.0.Final"))
                 .thenReturn(resolvedArtifactFile);
 
-        List<Channel> channels = ChannelMapper.fromString(
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "name: My Channel\n" +
-                        "requires:\n" +
-                        "  - groupId: org.foo\n" +
-                        "    artifactId: required-channel");
+                "requires:\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel");
         assertEquals(1, channels.size());
 
         try (ChannelSession session = new ChannelSession(channels, factory)) {
@@ -96,12 +97,12 @@ public class ChannelWithRequirementsTestCase {
         when(resolver.resolveArtifact("org.example", "foo-bar", null, null, "1.2.0.Final"))
                 .thenReturn(resolvedArtifactFile);
 
-        List<Channel> channels = ChannelMapper.fromString(
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "name: My Channel\n" +
-                        "requires:\n" +
-                        "  - groupId: org.foo\n" +
-                        "    artifactId: required-channel\n" +
-                        "    version: 2.0.0.Final");
+                "requires:\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel\n" +
+                "    version: 2.0.0.Final");
         assertEquals(1, channels.size());
 
         try (ChannelSession session = new ChannelSession(channels, factory)) {

--- a/core/src/test/java/org/wildfly/channel/StreamResolverTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/StreamResolverTestCase.java
@@ -19,6 +19,7 @@ package org.wildfly.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.util.Optional;
 
@@ -29,7 +30,8 @@ public class StreamResolverTestCase {
     @Test
     public void testFindingStreamMatchingArtifactIdAndGroupId() {
 
-        String yamlContent = "streams:\n" +
+        String yamlContent = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
                 "  - groupId: io.undertow\n" +
                 "    artifactId: '*'\n" +
                 "    version: 3.0.0.Final\n" +

--- a/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
@@ -19,6 +19,7 @@ package org.wildfly.channel.mapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,7 +102,8 @@ public class ChannelTestCase {
 
     @Test
     public void channelWithoutStreams() {
-        List<Channel> channels = ChannelMapper.fromString("name: My Channel\n" +
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "name: My Channel\n" +
                 "description: |-\n" +
                 "  This is my channel\n" +
                 "  with no stream");
@@ -113,7 +115,8 @@ public class ChannelTestCase {
 
     @Test
     public void channelWithRequires() {
-        List<Channel> channels = ChannelMapper.fromString("name: My Channel\n" +
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n"
+                +"name: My Channel\n" +
                 "description: |-\n" +
                 "  This is my channel\n" +
                 "  with no stream\n" +

--- a/core/src/test/java/org/wildfly/channel/schema/SchemaTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/schema/SchemaTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.channel.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelMapper;
+
+/**
+ * Test class to be able to read channels from released schemas
+ */
+public class SchemaTestCase {
+
+    @Test
+    public void testReadChannel_1_0_0() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("versions/channel-1.0.0.yaml");
+        Channel channel = ChannelMapper.from(file);
+        assertNotNull(channel);
+        assertEquals(ChannelMapper.SCHEMA_VERSION_1_0_0, channel.getSchemaVersion());
+    }
+
+    @Test
+    public void testReadChannelWithoutSchema() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("versions/channel-without-schema.yaml");
+        assertThrows(Exception.class, () -> {
+            ChannelMapper.from(file);
+        });
+    }
+}

--- a/core/src/test/resources/channels/channel-with-unknown-properties.yaml
+++ b/core/src/test/resources/channels/channel-with-unknown-properties.yaml
@@ -1,3 +1,4 @@
+schemaVersion: "1.0.0"
 name: My Channel
 description: |-
   This is my channel

--- a/core/src/test/resources/channels/multiple-channels.yaml
+++ b/core/src/test/resources/channels/multiple-channels.yaml
@@ -1,4 +1,6 @@
 ---
+schemaVersion:  "1.0.0"
 name: Channel for WildFly 27
 ---
+schemaVersion:  "1.0.0"
 name: Channel for WildFly 28

--- a/core/src/test/resources/channels/required-channel.yaml
+++ b/core/src/test/resources/channels/required-channel.yaml
@@ -1,3 +1,4 @@
+schemaVersion: "1.0.0"
 name: My Required Channel
 streams:
   - groupId: org.example

--- a/core/src/test/resources/channels/simple-channel.yaml
+++ b/core/src/test/resources/channels/simple-channel.yaml
@@ -1,3 +1,4 @@
+schemaVersion: "1.0.0"
 name: My Channel
 description: |-
   This is my channel

--- a/core/src/test/resources/versions/channel-1.0.0.yaml
+++ b/core/src/test/resources/versions/channel-1.0.0.yaml
@@ -1,0 +1,15 @@
+schemaVersion: "1.0.0"
+name: My Channel in schema version 1.0.0
+description: |-
+  This is my channel
+  with my stuff
+vendor:
+  name: My Vendor
+  support: community
+streams:
+  - groupId: org.example
+    artifactId: bar
+    version: 2.0.0.Final
+  - groupId: org.example
+    artifactId: foo
+    versionPattern: '2\.2\..*'

--- a/core/src/test/resources/versions/channel-without-schema.yaml
+++ b/core/src/test/resources/versions/channel-without-schema.yaml
@@ -1,0 +1,13 @@
+name: My Channel without schema
+description: |-
+  A channel without schema is validated with schema  1.0.0
+vendor:
+  name: My Vendor
+  support: community
+streams:
+  - groupId: org.example
+    artifactId: bar
+    version: 2.0.0.Final
+  - groupId: org.example
+    artifactId: foo
+    versionPattern: '2\.2\..*'

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -3,6 +3,11 @@
 
 ## WildFly Channels
 
+[cols="1,1"]
+|===
+| Schema Version | 1.0.0 |
+|===
+
 ### Summary
 
 This document describes the overall architecture and concepts related to Channels to provision WildFly.
@@ -68,7 +73,7 @@ A JSON Schema is provided to validate that channels comply with the model descri
 
 ## Channel Representation
 
-A channel is specified in the YAML language with a link:../core/src/main/resources/org/wildfly/channel/channel-schema.json[corresponding JSON schema] to validate its structure.
+A channel is specified in the YAML language with a link:../core/src/main/resources/org/wildfly/channel/v1.0.0./schema.json[corresponding JSON schema] to validate its structure.
 
 ### Channel Actions and Responsibilities
 
@@ -106,3 +111,10 @@ If the stream defines a `version`, the artifact will be resolved based on this v
 from the Maven repositories, an error is returned to the caller.
 If the stream defines a `versionPattern`, the version will be determined by querying the version of the artifacts from the
 Maven repositories and use the latest version that matches the pattern. If no version matches the pattern, an error is returned to the caller.
+
+### Changelog
+
+### Version 1.0.0
+
+* Initial release of the Channel specification
+

--- a/maven-resolver/src/test/resources/channels/channel.yaml
+++ b/maven-resolver/src/test/resources/channels/channel.yaml
@@ -1,3 +1,4 @@
+schemaVersion: "1.0.0"
 name: My Channel
 description: |-
   This is my channel


### PR DESCRIPTION
The schemaVersion field is a required field that specifies the version
of the schema supported by a Channel YAML file.

The current value of the schema is "1.0.0".

This fixes #56

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>