### PR TITLE
[#59] Add INFO logs for the origins of the channels

### DIFF
--- a/maven-resolver/pom.xml
+++ b/maven-resolver/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>channel-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/maven-resolver/src/main/java/org/wildfly/channel/maven/VersionResolverFactory.java
+++ b/maven-resolver/src/main/java/org/wildfly/channel/maven/VersionResolverFactory.java
@@ -44,8 +44,11 @@ import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
 import org.wildfly.channel.spi.MavenVersionsResolver;
 import org.wildfly.channel.version.VersionMatcher;
+import org.jboss.logging.Logger;
 
 public class VersionResolverFactory implements MavenVersionsResolver.Factory {
+
+    private static final Logger LOG = Logger.getLogger(VersionResolverFactory.class);
 
     private final RepositorySystem system;
     private final RepositorySystemSession session;
@@ -145,6 +148,7 @@ public class VersionResolverFactory implements MavenVersionsResolver.Factory {
             for (ChannelCoordinate channelCoord : channelCoords) {
                 if (channelCoord.getUrl() != null) {
                     Channel channel = ChannelMapper.from(channelCoord.getUrl());
+                    LOG.infof("Resolving channel at %s", channelCoord.getUrl());
                     channels.add(channel);
                     continue;
                 }
@@ -159,6 +163,7 @@ public class VersionResolverFactory implements MavenVersionsResolver.Factory {
                 }
                 File channelArtifact = resolver.resolveArtifact(channelCoord.getGroupId(), channelCoord.getArtifactId(), channelCoord.getExtension(), channelCoord.getClassifier(), version);
                 Channel channel = ChannelMapper.from(channelArtifact.toURI().toURL());
+                LOG.infof("Resolving channel from Maven artifact %s:%s:%s", channelCoord.getGroupId(), channelCoord.getArtifactId(), version);
                 channels.add(channel);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <version.com.fasterxml.jackson.databind>2.13.3</version.com.fasterxml.jackson.databind>
         <version.com.networknt.json-schema-validator>1.0.70</version.com.networknt.json-schema-validator>
         <version.junit5>5.8.2</version.junit5>
+        <version.org.jboss.logging>3.5.0.Final</version.org.jboss.logging>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.aether-api>1.1.0</version.aether-api>
         <version.maven-aether-provider>3.3.9</version.maven-aether-provider>
@@ -60,6 +61,11 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-aether-provider</artifactId>
                 <version>${version.maven-aether-provider}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.org.jboss.logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
When channels are resolved from URLs or Maven artifacts, log their
origins at the `INFO` level.

This fixes #59

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>