### PR TITLE
[#61] When deserializing YAML content, ignore unknown properties

### DIFF
--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -16,17 +16,14 @@
  */
 package org.wildfly.channel;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -51,7 +48,8 @@ public class ChannelMapper {
 
     private static final String SCHEMA_FILE = "org/wildfly/channel/channel-schema.json";
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
+            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
     private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)).objectMapper(OBJECT_MAPPER).build();
     private static final JsonSchema SCHEMA = SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_FILE));
 

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -16,11 +16,13 @@
  */
 package org.wildfly.channel;
 
+import java.net.URL;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ChannelMapperTestCase {
 
@@ -31,5 +33,14 @@ public class ChannelMapperTestCase {
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);
         assertEquals(Vendor.Support.COMMUNITY, channel1.getVendor().getSupport());
+    }
+
+    @Test
+    public void testReadChannelWithUnknownProperties() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/channel-with-unknown-properties.yaml");
+
+        Channel channel = ChannelMapper.from(file);
+        assertNotNull(channel);
     }
 }

--- a/core/src/test/resources/channels/channel-with-unknown-properties.yaml
+++ b/core/src/test/resources/channels/channel-with-unknown-properties.yaml
@@ -1,0 +1,13 @@
+name: My Channel
+description: |-
+  This is my channel
+  with properties that are not defined in the schema
+vendor:
+  name: My Vendor
+  support: community
+foo: not an known property
+streams:
+  - groupId: org.wildfly
+    artifactId: wildfly-ee-galleon-pack
+    version: 26.0.0.Final
+    bar: not a known property


### PR DESCRIPTION
This fixes #61

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>