### PR TITLE
[#65] Expose channel API

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.wildfly.channel.spi.MavenVersionsResolver;
@@ -88,6 +89,35 @@ public class Channel implements AutoCloseable {
 
     private MavenVersionsResolver resolver;
 
+    /**
+     * Representation of a Channel resource using the current schema version.
+     *
+     * @see #Channel(String, String, Vendor, List, Collection)
+     */
+    public Channel(String name,
+                   String description,
+                   Vendor vendor,
+                   List<ChannelRequirement> channelRequirements,
+                   Collection<Stream> streams) {
+        this(ChannelMapper.CURRENT_SCHEMA_VERSION,
+                name,
+                description,
+                vendor,
+                channelRequirements,
+                streams);
+    }
+
+    /**
+     * Representation of a Channel resource
+     *
+     * @param schemaVersion the version of the schema to validate this channel resource - required
+     * @param name the name of the channel - can be {@code null}
+     * @param description the description of the channel - can be {@code null}
+     * @param vendor the vendor of the channel - can be {@code null}
+     * @param channelRequirements the required channels - cane be {@code null}
+     * @param streams the streams defined by the channel - can be {@code null}
+     */
+    @JsonCreator
     public Channel(@JsonProperty(value = "schemaVersion", required = true) String schemaVersion,
                    @JsonProperty(value = "name") String name,
                    @JsonProperty(value = "description") String description,

--- a/core/src/main/java/org/wildfly/channel/ChannelRequirement.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelRequirement.java
@@ -16,6 +16,10 @@
  */
 package org.wildfly.channel;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -28,10 +32,20 @@ public class ChannelRequirement {
     private final String artifactId;
     private final String version;
 
+    /**
+     * Representation of a channel requirement.
+     *
+     * @param groupId groupId of the Maven coordinate - required
+     * @param artifactId artifactId of the Maven coordinate - required
+     * @param version version of the Maven coordinate - can be {@code null}
+    */
     @JsonCreator
-    ChannelRequirement(@JsonProperty(value = "groupId", required = true) String groupId,
+    public ChannelRequirement(@JsonProperty(value = "groupId", required = true) String groupId,
                        @JsonProperty(value = "artifactId", required = true) String artifactId,
                        @JsonProperty(value = "version") String version) {
+        requireNonNull(groupId);
+        requireNonNull(artifactId);
+
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;

--- a/core/src/main/java/org/wildfly/channel/Stream.java
+++ b/core/src/main/java/org/wildfly/channel/Stream.java
@@ -63,6 +63,34 @@ public class Stream implements Comparable<Stream> {
 
     private VersionMatcher versionMatcher;
 
+    /**
+     * @see #Stream(String, String, String, Pattern)
+     */
+    public Stream(String groupId,
+                  String artifactId,
+                  String version) {
+        this(groupId, artifactId, version, null);
+    }
+
+    /**
+     * @see #Stream(String, String, String, Pattern)
+     */
+    public Stream(String groupId,
+                  String artifactId,
+                  Pattern versionPattern) {
+        this(groupId, artifactId, null, versionPattern);
+    }
+
+    /**
+     * Representation of a stream resource
+     *
+     * @param groupId groupId of the Maven coordinate - required
+     * @param artifactId artifactId of the Maven coordinate - required
+     * @param version version of the Maven coordinate - can be {@code null}
+     * @param versionPattern version patter to determine the latest version of the resource - can be {@code null}
+     *
+     * Either {@code version} or {@code versionPattern} must be defined.
+     */
     @JsonCreator
     public Stream(@JsonProperty(value = "groupId", required = true) String groupId,
            @JsonProperty(value = "artifactId", required = true) String artifactId,

--- a/core/src/main/java/org/wildfly/channel/Vendor.java
+++ b/core/src/main/java/org/wildfly/channel/Vendor.java
@@ -34,6 +34,12 @@ public class Vendor {
      */
     private final Support support;
 
+    /**
+     * Vendor resource
+     *
+     * @param name Name of the vendor - required
+     * @param support Support level of the vendor - required
+     */
     @JsonCreator
     public Vendor(@JsonProperty(value = "name", required = true) String name, @JsonProperty(value = "support", required = true) Support support) {
         this.name = name;

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -22,6 +22,7 @@ import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.net.URL;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,11 +30,25 @@ public class ChannelMapperTestCase {
 
     @Test
     public void testWriteReadChannel() throws Exception {
-        final Channel channel = new Channel(CURRENT_SCHEMA_VERSION,"test_name", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final Channel channel = new Channel("test_name", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
         final String yaml = ChannelMapper.toYaml(channel);
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);
         assertEquals(Vendor.Support.COMMUNITY, channel1.getVendor().getSupport());
+    }
+
+    @Test
+    public void testWriteMultipleChannels() throws Exception {
+        final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final Channel channel2 = new Channel("test_name_2", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final String yaml = ChannelMapper.toYaml(channel1, channel2);
+
+        List<Channel> channels = ChannelMapper.fromString(yaml);
+        assertEquals(2, channels.size());
+        final Channel c1 = channels.get(0);
+        final Channel c2 = channels.get(1);
+        assertEquals(channel1.getName(), c1.getName());
+        assertEquals(channel2.getName(), c2.getName());
     }
 
     @Test


### PR DESCRIPTION
Allow use of the Channel API to create channel and generate valid YAML
content.

This fixes #65.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>