### PR TITLE
[#68] Orders the channel serialization so that `streams` is always last

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -37,6 +37,7 @@ import java.util.TreeSet;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.wildfly.channel.spi.MavenVersionsResolver;
 import org.wildfly.channel.version.VersionMatcher;
 
@@ -118,6 +119,7 @@ public class Channel implements AutoCloseable {
      * @param streams the streams defined by the channel - can be {@code null}
      */
     @JsonCreator
+    @JsonPropertyOrder({ "schemaVersion", "name", "description", "vendor", "requires", "streams" })
     public Channel(@JsonProperty(value = "schemaVersion", required = true) String schemaVersion,
                    @JsonProperty(value = "name") String name,
                    @JsonProperty(value = "description") String description,
@@ -157,6 +159,7 @@ public class Channel implements AutoCloseable {
     }
 
     @JsonInclude(NON_EMPTY)
+    @JsonProperty(value = "requires")
     public List<ChannelRequirement> getChannelRequirements() {
         return channelRequirements;
     }

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -17,6 +17,7 @@
 package org.wildfly.channel;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
@@ -32,9 +33,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
@@ -52,9 +57,11 @@ public class ChannelMapper {
     public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_0;
 
     private static final String SCHEMA_1_0_0_FILE = "org/wildfly/channel/v1.0.0/schema.json";
-    private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
+    private static final YAMLFactory YAML_FACTORY = new YAMLFactory()
+            .configure(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
-            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
     private static final JsonSchemaFactory SCHEMA_FACTORY = JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)).objectMapper(OBJECT_MAPPER).build();
     private static final Map<String, JsonSchema> SCHEMAS = new HashMap<>();
 

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -21,8 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,15 +41,21 @@ public class ChannelMapperTestCase {
 
     @Test
     public void testWriteMultipleChannels() throws Exception {
-        final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final ChannelRequirement req = new ChannelRequirement("org", "foo", "1.2.3");
+        final Stream stream1 = new Stream("org.bar", "example", "1.2.3");
+        final Stream stream2 = new Stream("org.bar", "other-example", Pattern.compile("\\.*"));
+        final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Arrays.asList(req), Arrays.asList(stream1, stream2));
         final Channel channel2 = new Channel("test_name_2", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
         final String yaml = ChannelMapper.toYaml(channel1, channel2);
 
+        System.out.println(yaml);
         List<Channel> channels = ChannelMapper.fromString(yaml);
         assertEquals(2, channels.size());
         final Channel c1 = channels.get(0);
-        final Channel c2 = channels.get(1);
         assertEquals(channel1.getName(), c1.getName());
+        assertEquals(1, c1.getChannelRequirements().size());
+        assertEquals("foo", c1.getChannelRequirements().get(0).getArtifactId());
+        final Channel c2 = channels.get(1);
         assertEquals(channel2.getName(), c2.getName());
     }
 


### PR DESCRIPTION
This fixes #68.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>