### PR TITLE
Add test cases for stream version inheritance when requiring channels

### DIFF
--- a/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
@@ -385,6 +385,7 @@ public class ChannelWithRequirementsTestCase {
 
     /**
      * Test that multiple requirements are propagating artifacts versions correctly
+     * If multiple required channels define the same stream, newest defined version of the stream will be used
      */
     @Test
     public void testChannelMultipleRequirements() throws UnresolvedMavenArtifactException, URISyntaxException {
@@ -420,9 +421,6 @@ public class ChannelWithRequirementsTestCase {
         when(resolver.resolveArtifact("org.example", "im-only-in-required-channel", null, null, "2.0.0.Final"))
                 .thenReturn(mock(File.class));
 
-        // If the channel requires other channels, these will be searched first in their listed order.
-        // The first stream that is found matching the groupId/artifactId will be used to determine the version of the artifact to pull.
-        // Therefore version of foo-bar from required-channel should be used
         List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "name: root level requiring channel\n" +
                 "requires:\n" +
@@ -441,7 +439,7 @@ public class ChannelWithRequirementsTestCase {
             assertEquals("foo-bar", artifact.getArtifactId());
             assertNull(artifact.getExtension());
             assertNull(artifact.getClassifier());
-            assertEquals("1.2.0.Final", artifact.getVersion());
+            assertEquals("2.0.0.Final", artifact.getVersion());
 
             // im-only-in-required-channel should propagate to the root level channel
             artifact = session.resolveMavenArtifact("org.example", "im-only-in-required-channel", null, null, "0");
@@ -453,8 +451,7 @@ public class ChannelWithRequirementsTestCase {
             assertNull(artifact.getClassifier());
             assertEquals("1.0.0.Final", artifact.getVersion());
         }
-        // required-channel-2 has newer version of foo-bar artifact,
-        // and as it is listed first, the 2.0.0 version of foo-bar should be used
+
         channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
                 "name: root level requiring channel\n" +
                 "requires:\n" +

--- a/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelWithRequirementsTestCase.java
@@ -333,7 +333,7 @@ public class ChannelWithRequirementsTestCase {
 
         // check that root level can override all streams from required channels
         channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
-                "name: root level requiring channel\n"+
+                "name: root level requiring channel\n" +
                 "requires:\n" +
                 "  - groupId: org.foo\n" +
                 "    artifactId: 2nd-level-requiring-channel\n" +
@@ -380,6 +380,111 @@ public class ChannelWithRequirementsTestCase {
             assertNull(artifact.getExtension());
             assertNull(artifact.getClassifier());
             assertEquals("2.0.0.Final", artifact.getVersion());
+        }
+    }
+
+    /**
+     * Test that multiple requirements are propagating artifacts versions correctly
+     */
+    @Test
+    public void testChannelMultipleRequirements() throws UnresolvedMavenArtifactException, URISyntaxException {
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL resolvedRequiredChannelURL = tccl.getResource("channels/required-channel.yaml");
+        File resolvedRequiredChannelFile = Paths.get(resolvedRequiredChannelURL.toURI()).toFile();
+        URL resolvedRequiredChannel2URL = tccl.getResource("channels/required-channel-2.yaml");
+        File resolvedRequiredChannel2File = Paths.get(resolvedRequiredChannel2URL.toURI()).toFile();
+
+        when(factory.create())
+                .thenReturn(resolver);
+        when(resolver.resolveArtifact("org.foo", "required-channel", "yaml", "channel", "2.0.0.Final"))
+                .thenReturn(resolvedRequiredChannelFile);
+        when(resolver.resolveArtifact("org.foo", "required-channel-2", "yaml", "channel", "2.0.0.Final"))
+                .thenReturn(resolvedRequiredChannel2File);
+
+        when(resolver.getAllVersions("org.example", "foo-bar", null, null))
+                .thenReturn(Set.of("1.0.0.Final", "1.2.0.Final", "2.0.0.Final"));
+        when(resolver.getAllVersions("org.example", "im-only-in-required-channel", null, null))
+                .thenReturn(Set.of("1.0.0.Final", "2.0.0.Final"));
+
+        when(resolver.resolveArtifact("org.example", "foo-bar", null, null, "1.0.0.Final"))
+                .thenReturn(mock(File.class));
+        when(resolver.resolveArtifact("org.example", "foo-bar", null, null, "1.2.0.Final"))
+                .thenReturn(mock(File.class));
+        when(resolver.resolveArtifact("org.example", "foo-bar", null, null, "2.0.0.Final"))
+                .thenReturn(mock(File.class));
+        when(resolver.resolveArtifact("org.example", "im-only-in-required-channel", null, null, "1.0.0.Final"))
+                .thenReturn(mock(File.class));
+        when(resolver.resolveArtifact("org.example", "im-only-in-required-channel", null, null, "2.0.0.Final"))
+                .thenReturn(mock(File.class));
+
+        // If the channel requires other channels, these will be searched first in their listed order.
+        // The first stream that is found matching the groupId/artifactId will be used to determine the version of the artifact to pull.
+        // Therefore version of foo-bar from required-channel should be used
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "name: root level requiring channel\n" +
+                "requires:\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel\n" +
+                "    version: 2.0.0.Final\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel-2\n" +
+                "    version: 2.0.0.Final");
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact artifact = session.resolveMavenArtifact("org.example", "foo-bar", null, null, "0");
+            assertNotNull(artifact);
+
+            assertEquals("org.example", artifact.getGroupId());
+            assertEquals("foo-bar", artifact.getArtifactId());
+            assertNull(artifact.getExtension());
+            assertNull(artifact.getClassifier());
+            assertEquals("1.2.0.Final", artifact.getVersion());
+
+            // im-only-in-required-channel should propagate to the root level channel
+            artifact = session.resolveMavenArtifact("org.example", "im-only-in-required-channel", null, null, "0");
+            assertNotNull(artifact);
+
+            assertEquals("org.example", artifact.getGroupId());
+            assertEquals("im-only-in-required-channel", artifact.getArtifactId());
+            assertNull(artifact.getExtension());
+            assertNull(artifact.getClassifier());
+            assertEquals("1.0.0.Final", artifact.getVersion());
+        }
+        // required-channel-2 has newer version of foo-bar artifact,
+        // and as it is listed first, the 2.0.0 version of foo-bar should be used
+        channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "name: root level requiring channel\n" +
+                "requires:\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel-2\n" +
+                "    version: 2.0.0.Final\n" +
+                "  - groupId: org.foo\n" +
+                "    artifactId: required-channel\n" +
+                "    version: 2.0.0.Final"
+        );
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact artifact = session.resolveMavenArtifact("org.example", "foo-bar", null, null, "0");
+            assertNotNull(artifact);
+
+            assertEquals("org.example", artifact.getGroupId());
+            assertEquals("foo-bar", artifact.getArtifactId());
+            assertNull(artifact.getExtension());
+            assertNull(artifact.getClassifier());
+            assertEquals("2.0.0.Final", artifact.getVersion());
+
+            // im-only-in-required-channel should propagate to the root level channel
+            artifact = session.resolveMavenArtifact("org.example", "im-only-in-required-channel", null, null, "0");
+            assertNotNull(artifact);
+
+            assertEquals("org.example", artifact.getGroupId());
+            assertEquals("im-only-in-required-channel", artifact.getArtifactId());
+            assertNull(artifact.getExtension());
+            assertNull(artifact.getClassifier());
+            assertEquals("1.0.0.Final", artifact.getVersion());
         }
     }
 }

--- a/core/src/test/resources/channels/required-channel-2.yaml
+++ b/core/src/test/resources/channels/required-channel-2.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "1.0.0"
+name: My Required Channel
+streams:
+  - groupId: org.example
+    artifactId: foo-bar
+    version: 2.0.0.Final

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -102,9 +102,11 @@ A Maven artifact can be resolved through a channel.
 Such a resolution will use the Maven repositories configured by the provisioning tool.
 
 The channels will be searched for a stream that matches the `groupId`/`artifactId` of the artifact.
-If the channel `requires` other channels, these will be searched first in their listed order.
 
-The first stream that is found matching the `groupId`/`artifactId` will be used to determine the version of the artifact to pull.
+If a channel directly defines a stream that matches the groupId/artifactId of the artifact, the version will be resolved from this stream.
+
+If channel does not directly define a stream, required channels will be searched. The latest version of the stream found in the required channels will be used.
+
 If no stream that matches the artifact have been found, an error is returned to the caller.
 
 If the stream defines a `version`, the artifact will be resolved based on this version. If that version of the artifact can not be pulled


### PR DESCRIPTION
Add check that multiple requirements are all processed
Add check that when multiple requirements require the same library, the newest version is used