### PR TITLE
List unresolved artifacts

### DIFF
--- a/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
+++ b/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
@@ -16,7 +16,13 @@
  */
 package org.wildfly.channel;
 
+import java.util.Collections;
+import java.util.Set;
+
 public class UnresolvedMavenArtifactException extends RuntimeException {
+
+    private Set<ArtifactCoordinate> unresolvedArtifacts = Collections.emptySet();
+
     public UnresolvedMavenArtifactException(String message) {
         super(message);
     }
@@ -25,7 +31,14 @@ public class UnresolvedMavenArtifactException extends RuntimeException {
         super();
     }
 
-    public UnresolvedMavenArtifactException(String message, Throwable cause) {
-        super(message, cause);
+    public UnresolvedMavenArtifactException(String localizedMessage,
+                                            Throwable cause,
+                                            Set<ArtifactCoordinate> unresolvedArtifacts) {
+        super(localizedMessage, cause);
+        this.unresolvedArtifacts = unresolvedArtifacts;
+    }
+
+    public Set<ArtifactCoordinate> getUnresolvedArtifacts() {
+        return unresolvedArtifacts;
     }
 }


### PR DESCRIPTION
Add a set of unresolved artifacts to the `UnresolvedMavenArtifactException`.

The default aether error message is misleading as it mentions only first failed artifact and only a single repository that was attempted.
Listing all failed artifacts allows API consumers to provide better failure information.