### PR TITLE
[#97] No resolve strategies

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -20,6 +20,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
+import static org.wildfly.channel.version.VersionMatcher.COMPARATOR;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -47,6 +49,30 @@ public class Channel implements AutoCloseable {
 
     public static final String CLASSIFIER="channel";
     public static final String EXTENSION="yaml";
+
+    /**
+     * Strategies for resolving artifact versions if it is not listed in streams.
+     * <ul>
+     *    <li>LATEST - Use the latest version according to {@link VersionMatcher#COMPARATOR}</li>
+     *    <li>ORIGINAL - Use the {@code baseVersion} if provided in the query</li>
+     *    <li>MAVEN_LATEST - Use the value of {@code <latest>} in maven-metadata.xml</li>
+     *    <li>MAVEN_RELEASE - Use the value of {@code <release>} in maven-metadata.xml</li>
+     *    <li>NONE - throw {@link UnresolvedMavenArtifactException}</li>
+     * </ul>
+     */
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    public enum NoStreamStrategy {
+        @JsonProperty("latest")
+        LATEST,
+        @JsonProperty("original")
+        ORIGINAL,
+        @JsonProperty("maven-latest")
+        MAVEN_LATEST,
+        @JsonProperty("maven-release")
+        MAVEN_RELEASE,
+        @JsonProperty("none")
+        NONE
+    }
 
     /** Version of the schema used by this channel.
      * This is a required field.
@@ -84,6 +110,12 @@ public class Channel implements AutoCloseable {
     private List<Channel> requiredChannels = Collections.emptyList();
 
     /**
+     * Strategy for resolving artifact versions if it is not listed in streams.
+     * This is an optional field. If not specified 'LATEST' strategy is used.
+     */
+    private NoStreamStrategy noStreamStrategy;
+
+    /**
      * Optional channel manifest specifying streams.
      */
     private ChannelManifest channelManifest;
@@ -103,36 +135,23 @@ public class Channel implements AutoCloseable {
     /**
      * Representation of a Channel resource using the current schema version.
      *
-     * @see #Channel(String, String, Vendor, List, List, ChannelManifestCoordinate)
+     * @see #Channel(String, String, Vendor, List, List, ChannelManifestCoordinate, NoStreamStrategy)
      */
     public Channel(String name,
                    String description,
                    Vendor vendor,
                    List<ChannelRequirement> channelRequirements,
                    List<Repository> repositories,
-                   ChannelManifestCoordinate manifestCoordinate) {
+                   ChannelManifestCoordinate manifestCoordinate,
+                   NoStreamStrategy noStreamStrategy){
         this(ChannelMapper.CURRENT_SCHEMA_VERSION,
                 name,
                 description,
                 vendor,
                 channelRequirements,
                 repositories,
-                manifestCoordinate);
-    }
-
-    Channel(String name,
-                   String description,
-                   Vendor vendor,
-                   List<ChannelRequirement> channelRequirements,
-                   ChannelManifest channelManifest) {
-        this(ChannelMapper.CURRENT_SCHEMA_VERSION,
-                name,
-                description,
-                vendor,
-                channelRequirements,
-                emptyList(),
-                null);
-        this.channelManifest = channelManifest;
+                manifestCoordinate,
+                noStreamStrategy);
     }
 
     /**
@@ -143,6 +162,8 @@ public class Channel implements AutoCloseable {
      * @param description the description of the channel - can be {@code null}
      * @param vendor the vendor of the channel - can be {@code null}
      * @param channelRequirements the required channels - cane be {@code null}
+     * @param channelRequirements the required channels - can be {@code null}
+     * @param noStreamStrategy - strategy for resolving version if the artifact is not listed in steams - can be {@code null}
      */
     @JsonCreator
     @JsonPropertyOrder({ "schemaVersion", "name", "description", "vendor", "requires", "streams" })
@@ -154,7 +175,8 @@ public class Channel implements AutoCloseable {
                    @JsonInclude(NON_EMPTY) List<ChannelRequirement> channelRequirements,
                    @JsonProperty(value = "repositories")
                    @JsonInclude(NON_EMPTY) List<Repository> repositories,
-                   @JsonProperty(value = "manifest") ChannelManifestCoordinate manifestCoordinate) {
+                   @JsonProperty(value = "manifest") ChannelManifestCoordinate manifestCoordinate,
+                   @JsonProperty(value = "resolves-if-no-stream") NoStreamStrategy noStreamStrategy) {
         this.schemaVersion = schemaVersion;
         this.name = name;
         this.description = description;
@@ -162,6 +184,7 @@ public class Channel implements AutoCloseable {
         this.channelRequirements = (channelRequirements != null) ? channelRequirements : emptyList();
         this.repositories = (repositories != null) ? repositories : emptyList();
         this.manifestCoordinate = manifestCoordinate;
+        this.noStreamStrategy = (noStreamStrategy != null) ? noStreamStrategy: NoStreamStrategy.ORIGINAL;
     }
 
     @JsonInclude
@@ -200,6 +223,11 @@ public class Channel implements AutoCloseable {
         return manifestCoordinate;
     }
 
+    @JsonInclude(NON_EMPTY)
+    public NoStreamStrategy getNoStreamStrategy() {
+        return noStreamStrategy;
+    }
+
     void init(MavenVersionsResolver.Factory factory) {
         resolver = factory.create(repositories);
 
@@ -231,6 +259,10 @@ public class Channel implements AutoCloseable {
                 final File file;
                 file = resolver.resolveArtifact(groupId, artifactId, EXTENSION, CLASSIFIER, version);
                 Channel requiredChannel = ChannelMapper.from(file.toURI().toURL());
+                requiredChannel = new Channel(requiredChannel.schemaVersion, requiredChannel.name,
+                                              requiredChannel.description, requiredChannel.vendor,
+                                              requiredChannel.channelRequirements, requiredChannel.repositories,
+                                              requiredChannel.manifestCoordinate, NoStreamStrategy.NONE);
                 requiredChannel.init(factory);
                 requiredChannels.add(requiredChannel);
             } catch (UnresolvedMavenArtifactException | MalformedURLException e) {
@@ -265,7 +297,7 @@ public class Channel implements AutoCloseable {
                 .findFirst().orElseThrow();
     }
 
-    Optional<ResolveLatestVersionResult> resolveLatestVersion(String groupId, String artifactId, String extension, String classifier) {
+    Optional<ResolveLatestVersionResult> resolveLatestVersion(String groupId, String artifactId, String extension, String classifier, String baseVersion) {
         requireNonNull(groupId);
         requireNonNull(artifactId);
         requireNonNull(resolver);
@@ -278,16 +310,37 @@ public class Channel implements AutoCloseable {
             // we return the latest value from the required channels
             Map<String, Channel> foundVersions = new HashMap<>();
             for (Channel requiredChannel : requiredChannels) {
-                Optional<Channel.ResolveLatestVersionResult> found = requiredChannel.resolveLatestVersion(groupId, artifactId, extension, classifier);
+                Optional<Channel.ResolveLatestVersionResult> found = requiredChannel.resolveLatestVersion(groupId, artifactId, extension, classifier, baseVersion);
                 if (found.isPresent()) {
                     foundVersions.put(found.get().version, found.get().channel);
                 }
             }
-            Optional<String> foundVersionInRequiredChannels = foundVersions.keySet().stream().sorted(VersionMatcher.COMPARATOR.reversed()).findFirst();
+            Optional<String> foundVersionInRequiredChannels = foundVersions.keySet().stream().sorted(COMPARATOR.reversed()).findFirst();
             if (foundVersionInRequiredChannels.isPresent()) {
                 return Optional.of(new ResolveLatestVersionResult(foundVersionInRequiredChannels.get(), foundVersions.get(foundVersionInRequiredChannels.get())));
             }
-            return Optional.empty();
+
+            // finally try the NoStreamStrategy
+            switch (noStreamStrategy) {
+                case ORIGINAL:
+                    return Optional.of(new ResolveLatestVersionResult(baseVersion, this));
+                case LATEST:
+                    Set<String> versions = resolver.getAllVersions(groupId, artifactId, extension, classifier);
+                    final Optional<String> latestVersion = versions.stream().sorted(COMPARATOR.reversed()).findFirst();
+                    if (latestVersion.isPresent()) {
+                        return Optional.of(new ResolveLatestVersionResult(latestVersion.get(), this));
+                    } else {
+                        return Optional.empty();
+                    }
+                case MAVEN_LATEST:
+                    String latestMetadataVersion = resolver.getMetadataLatestVersion(groupId, artifactId);
+                    return Optional.of(new ResolveLatestVersionResult(latestMetadataVersion, this));
+                case MAVEN_RELEASE:
+                    String releaseMetadataVersion = resolver.getMetadataReleaseVersion(groupId, artifactId);
+                    return Optional.of(new ResolveLatestVersionResult(releaseMetadataVersion, this));
+                default:
+                    return Optional.empty();
+            }
         }
 
         Stream stream = foundStream.get();

--- a/core/src/main/java/org/wildfly/channel/ChannelManifest.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.channel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Java representation of a Channel Manifest.
+ */
+public class ChannelManifest {
+
+    public static final String CLASSIFIER="manifest";
+    public static final String EXTENSION="yaml";
+
+    /**
+     * Version of the schema used by this manifest.
+     * This is a required field.
+     */
+    private final String schemaVersion;
+
+    /**
+     * Optional manifest name.
+     * Short, one-line description of the manifest
+     */
+    private final String name;
+
+    /**
+     * Optional description of the manifest. It can use multiple lines.
+     */
+    private final String description;
+
+    /**
+     * Streams of components that are provided by this manifest.
+     */
+    private Set<Stream> streams;
+
+    /**
+     * Representation of a ChannelManifest resource using the current schema version.
+     *
+     * @see #ChannelManifest(String, String, String, Collection)
+     */
+    public ChannelManifest(String name,
+                           String description,
+                           Collection<Stream> streams) {
+        this(ChannelManifestMapper.CURRENT_SCHEMA_VERSION,
+                name,
+                description,
+                streams);
+    }
+
+    /**
+     * Representation of a Channel resource
+     *
+     * @param schemaVersion the version of the schema to validate this manifest resource - required
+     * @param name the name of the manifest - can be {@code null}
+     * @param description the description of the manifest - can be {@code null}
+     * @param streams the streams defined by the manifest - can be {@code null}
+     */
+    @JsonCreator
+    @JsonPropertyOrder({ "schemaVersion", "name", "description", "streams" })
+    public ChannelManifest(@JsonProperty(value = "schemaVersion", required = true) String schemaVersion,
+                           @JsonProperty(value = "name") String name,
+                           @JsonProperty(value = "description") String description,
+                           @JsonProperty(value = "streams") Collection<Stream> streams) {
+        this.schemaVersion = schemaVersion;
+        this.name = name;
+        this.description = description;
+        this.streams = new TreeSet<>();
+        if (streams != null) {
+            this.streams.addAll(streams);
+        }
+    }
+
+    @JsonInclude
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    @JsonInclude(NON_NULL)
+    public String getName() {
+        return name;
+    }
+
+    @JsonInclude(NON_NULL)
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonInclude(NON_EMPTY)
+    public Collection<Stream> getStreams() {
+        return streams;
+    }
+
+    public Optional<Stream> findStreamFor(String groupId, String artifactId) {
+        // first exact match:
+        Optional<Stream> stream = streams.stream().filter(s -> s.getGroupId().equals(groupId) && s.getArtifactId().equals(artifactId)).findFirst();
+        if (stream.isPresent()) {
+            return stream;
+        }
+        // check if there is a stream for groupId:*
+        stream = streams.stream().filter(s -> s.getGroupId().equals(groupId) && s.getArtifactId().equals("*")).findFirst();
+        return stream;
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/ChannelManifestCoordinate.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifestCoordinate.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.channel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * A channel manifest coordinate. Uses either a Maven coordinates (groupId, artifactId, version)
+ * or a URL from which the channel manifest file can be fetched.
+ */
+@JsonIgnoreProperties(value = {"groupId", "artifactId", "version", "classifier", "extension"})
+public class ChannelManifestCoordinate extends ChannelMetadataCoordinate {
+    public ChannelManifestCoordinate(String groupId, String artifactId, String version) {
+        super(groupId, artifactId, version, ChannelManifest.CLASSIFIER, ChannelManifest.EXTENSION);
+    }
+
+    public ChannelManifestCoordinate(String groupId, String artifactId) {
+        super(groupId, artifactId, ChannelManifest.CLASSIFIER, ChannelManifest.EXTENSION);
+    }
+
+    public ChannelManifestCoordinate(URL url) {
+        super(url);
+    }
+
+    @JsonCreator
+    public static ChannelManifestCoordinate create(@JsonProperty(value = "url") String url, @JsonProperty(value = "maven") MavenCoordinate gav) throws MalformedURLException {
+        if (gav != null) {
+            if (gav.getVersion() == null || gav.getVersion().isEmpty()) {
+                return new ChannelManifestCoordinate(gav.getGroupId(), gav.getArtifactId());
+            } else {
+                return new ChannelManifestCoordinate(gav.getGroupId(), gav.getArtifactId(), gav.getVersion());
+            }
+        } else {
+            return new ChannelManifestCoordinate(new URL(url));
+        }
+    }
+
+    @JsonProperty(value = "maven")
+    @JsonInclude(NON_NULL)
+    public MavenCoordinate getMaven() {
+        if (isEmpty(getGroupId()) || isEmpty(getArtifactId())) {
+            return null;
+        }
+        return new MavenCoordinate(getGroupId(), getArtifactId(), getVersion());
+    }
+
+    private boolean isEmpty(String text) {
+        return text == null || text.isEmpty();
+    }
+
+    @JsonProperty(value = "url")
+    @JsonInclude(NON_NULL)
+    @Override
+    public URL getUrl() {
+        return super.getUrl();
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
@@ -16,25 +16,6 @@
  */
 package org.wildfly.channel;
 
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
-import static java.util.Collections.singletonList;
-import static java.util.Objects.requireNonNull;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -45,19 +26,33 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+
 /**
  * Mapper class to transform YAML content (from URL or String) to Channel objects (and vice versa).
  *
  * YAML input is validated against a schema.
  */
-public class ChannelMapper {
+public class ChannelManifestMapper {
 
     public static final String SCHEMA_VERSION_1_0_0 = "1.0.0";
-    public static final String SCHEMA_VERSION_2_0_0 = "2.0.0";
-    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_2_0_0;
+    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_0;
 
-    private static final String SCHEMA_1_0_0_FILE = "org/wildfly/channel/v1.0.0/schema.json";
-    private static final String SCHEMA_2_0_0_FILE = "org/wildfly/channel/v2.0.0/schema.json";
+    private static final String SCHEMA_1_0_0_FILE = "org/wildfly/manifest/v1.0.0/schema.json";
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory()
             .configure(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
@@ -67,15 +62,14 @@ public class ChannelMapper {
     private static final Map<String, JsonSchema> SCHEMAS = new HashMap<>();
 
     static {
-        SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
-        SCHEMAS.put(SCHEMA_VERSION_2_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_2_0_0_FILE)));
+        SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelManifestMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
     }
 
     private static JsonSchema getSchema(JsonNode node) {
         JsonNode schemaVersion = node.path("schemaVersion");
         String version = schemaVersion.asText();
         if (version == null || version.isEmpty()) {
-            throw new RuntimeException("The channel does not specify a schemaVersion.");
+            throw new RuntimeException("The manifest does not specify a schemaVersion.");
         }
         JsonSchema schema = SCHEMAS.get(version);
         if (schema == null) {
@@ -84,51 +78,45 @@ public class ChannelMapper {
         return schema;
     }
 
-    public static String toYaml(Channel... channels) throws IOException {
-        return toYaml(Arrays.asList(channels));
-    }
-
-    public static String toYaml(List<Channel> channels) throws IOException {
-        Objects.requireNonNull(channels);
+    public static String toYaml(ChannelManifest channelManifest) throws IOException {
+        Objects.requireNonNull(channelManifest);
         StringWriter w = new StringWriter();
-        for (Channel channel : channels) {
-            OBJECT_MAPPER.writeValue(w, channel);
-        }
+        OBJECT_MAPPER.writeValue(w, channelManifest);
         return w.toString();
     }
 
-    public static Channel from(URL channelURL) throws InvalidChannelException {
-        requireNonNull(channelURL);
+    public static ChannelManifest from(URL manifestURL) throws InvalidChannelException {
+        requireNonNull(manifestURL);
 
         try {
             // QoL improvement
-            if (channelURL.toString().endsWith("/")) {
-                channelURL = channelURL.toURI().resolve("channel.yaml").toURL();
+            if (manifestURL.toString().endsWith("/")) {
+                manifestURL = manifestURL.toURI().resolve("channel.yaml").toURL();
             }
 
-            List<String> messages = validate(channelURL);
+            List<String> messages = validate(manifestURL);
             if (!messages.isEmpty()) {
-                throw new InvalidChannelException("Invalid channel", messages);
+                throw new InvalidChannelException("Invalid manifest", messages);
             }
-            Channel channel = OBJECT_MAPPER.readValue(channelURL, Channel.class);
-            return channel;
+            ChannelManifest channelManifest = OBJECT_MAPPER.readValue(manifestURL, ChannelManifest.class);
+            return channelManifest;
         } catch (IOException | URISyntaxException e) {
             throw wrapException(e);
         }
     }
 
-    public static List<Channel> fromString(String yamlContent) throws InvalidChannelException {
+    public static ChannelManifest fromString(String yamlContent) throws InvalidChannelException {
         requireNonNull(yamlContent);
 
         try {
             List<String> messages = validateString(yamlContent);
             if (!messages.isEmpty()) {
-                throw new InvalidChannelException("Invalid channel", messages);
+                throw new InvalidChannelException("Invalid manifest", messages);
             }
 
             YAMLParser parser = YAML_FACTORY.createParser(yamlContent);
-            List<Channel> channels = OBJECT_MAPPER.readValues(parser, Channel.class).readAll();
-            return channels;
+            ChannelManifest channelManifest = OBJECT_MAPPER.readValue(parser, ChannelManifest.class);
+            return channelManifest;
         } catch (IOException e) {
             throw wrapException(e);
         }
@@ -149,7 +137,7 @@ public class ChannelMapper {
     }
 
     private static InvalidChannelException wrapException(Exception e) {
-        InvalidChannelException ice = new InvalidChannelException("Invalid Channel", singletonList(e.getLocalizedMessage()));
+        InvalidChannelException ice = new InvalidChannelException("Invalid Manifest", singletonList(e.getLocalizedMessage()));
         ice.initCause(e);
         return ice;
     }

--- a/core/src/main/java/org/wildfly/channel/ChannelMetadataCoordinate.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMetadataCoordinate.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.channel;
+
+import java.net.URL;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A coordinate of Channel metadata artefacts (channel or manifest).
+ * Uses either a Maven coordinates (groupId, artifactId, version)
+ * or a URL from which the metadata file can be fetched.
+ */
+public class ChannelMetadataCoordinate {
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String classifier;
+    private String extension;
+
+    private URL url;
+
+    protected ChannelMetadataCoordinate() {
+    }
+
+    public ChannelMetadataCoordinate(String groupId, String artifactId, String version, String classifier, String extension) {
+        this(groupId, artifactId, version, classifier, extension, null);
+        requireNonNull(groupId);
+        requireNonNull(artifactId);
+        requireNonNull(version);
+    }
+
+    public ChannelMetadataCoordinate(String groupId, String artifactId, String classifier, String extension) {
+        this(groupId, artifactId, null, classifier, extension, null);
+        requireNonNull(groupId);
+        requireNonNull(artifactId);
+    }
+
+    public ChannelMetadataCoordinate(URL url) {
+        this(null, null, null, null, null, url);
+        requireNonNull(url);
+    }
+
+    private ChannelMetadataCoordinate(String groupId, String artifactId, String version, String classifier, String extension, URL url) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.classifier = classifier;
+        this.extension = extension;
+        this.url = url;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelMetadataCoordinate that = (ChannelMetadataCoordinate) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId) && Objects.equals(version, that.version) && Objects.equals(classifier, that.classifier) && Objects.equals(extension, that.extension) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version, classifier, extension, url);
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
@@ -29,6 +29,6 @@ class ChannelRecorder {
     ChannelManifest getRecordedChannel() {
         return new ChannelManifest(null,
                            null,
-                            new ArrayList<Stream>(streams.values()));
+                            new ArrayList<>(streams.values()));
     }
 }

--- a/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
@@ -26,10 +26,9 @@ class ChannelRecorder {
         streams.putIfAbsent(groupId + ":" + artifactId + ":" + version, new Stream(groupId, artifactId, version, null));
     }
 
-    Channel getRecordedChannel() {
-        return new Channel(null,
+    ChannelManifest getRecordedChannel() {
+        return new ChannelManifest(null,
                            null,
-                           null,
-                           null, new ArrayList<Stream>(streams.values()));
+                            new ArrayList<Stream>(streams.values()));
     }
 }

--- a/core/src/main/java/org/wildfly/channel/ChannelSession.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelSession.java
@@ -214,7 +214,7 @@ public class ChannelSession implements AutoCloseable {
 
         Map<String, Channel.ResolveLatestVersionResult> foundVersions = new HashMap<>();
         for (Channel channel : channels) {
-            Optional<Channel.ResolveLatestVersionResult> result = channel.resolveLatestVersion(groupId, artifactId, extension, classifier);
+            Optional<Channel.ResolveLatestVersionResult> result = channel.resolveLatestVersion(groupId, artifactId, extension, classifier, baseVersion);
             if (result.isPresent()) {
                 foundVersions.put(result.get().version, result.get());
             }

--- a/core/src/main/java/org/wildfly/channel/MavenCoordinate.java
+++ b/core/src/main/java/org/wildfly/channel/MavenCoordinate.java
@@ -1,0 +1,60 @@
+package org.wildfly.channel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+public class MavenCoordinate {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+
+    @JsonCreator
+    public MavenCoordinate(@JsonProperty(value = "groupId") String groupId,
+                           @JsonProperty(value = "artifactId") String artifactId,
+                           @JsonProperty(value = "version") String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    @JsonInclude(NON_NULL)
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "MavenCoordinate{" +
+                "groupId='" + groupId + '\'' +
+                ", artifactId='" + artifactId + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MavenCoordinate that = (MavenCoordinate) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId, version);
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/Repository.java
+++ b/core/src/main/java/org/wildfly/channel/Repository.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.channel;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class Repository {
+    private String id;
+    private String url;
+
+    @JsonCreator
+    public Repository(@JsonProperty(value = "id") String id, @JsonProperty(value = "url") String url) {
+        this.id = id;
+        this.url = url;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Repository that = (Repository) o;
+        return Objects.equals(id, that.id) && Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, url);
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
+++ b/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
@@ -38,6 +38,11 @@ public class UnresolvedMavenArtifactException extends RuntimeException {
         this.unresolvedArtifacts = unresolvedArtifacts;
     }
 
+    public <E> UnresolvedMavenArtifactException(String message, Set<ArtifactCoordinate> unresolvedArtifacts) {
+        super(message);
+        this.unresolvedArtifacts = unresolvedArtifacts;
+    }
+
     public Set<ArtifactCoordinate> getUnresolvedArtifacts() {
         return unresolvedArtifacts;
     }

--- a/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
+++ b/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
@@ -92,6 +92,30 @@ public interface MavenVersionsResolver extends Closeable {
     */
    List<URL> resolveChannelMetadata(List<? extends ChannelMetadataCoordinate> manifestCoords) throws UnresolvedMavenArtifactException;
 
+   /**
+    * Returns the {@code <release>} version according to the repositories' Maven metadata. If multiple repositories
+    * contain the same artifact, {@link org.wildfly.channel.version.VersionMatcher#COMPARATOR} is used to choose version.
+    *
+    * @param groupId Maven GroupId - required
+    * @param artifactId Maven ArtifactId - required
+    *
+    * @return the {@code release} version.
+    * @throws UnresolvedMavenArtifactException if the metadata can not be resolved or is incomplete.
+    */
+   String getMetadataReleaseVersion(String groupId, String artifactId);
+
+   /**
+    * Returns the {@code <latest>} version according to the repositories' Maven metadata. If multiple repositories
+    * contain the same artifact, {@link org.wildfly.channel.version.VersionMatcher#COMPARATOR} is used to choose version.
+    *
+    * @param groupId Maven GroupId - required
+    * @param artifactId Maven ArtifactId - required
+    *
+    * @return the {@code latest} version.
+    * @throws UnresolvedMavenArtifactException if the metadata can not be resolved or is incomplete.
+    */
+   String getMetadataLatestVersion(String groupId, String artifactId);
+
    default void close() {
    }
 

--- a/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
+++ b/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
@@ -18,10 +18,14 @@ package org.wildfly.channel.spi;
 
 import java.io.Closeable;
 import java.io.File;
+import java.net.URL;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ChannelMetadataCoordinate;
+import org.wildfly.channel.Repository;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
 
 /**
@@ -70,6 +74,24 @@ public interface MavenVersionsResolver extends Closeable {
     */
    List<File> resolveArtifacts(List<ArtifactCoordinate> coordinates) throws UnresolvedMavenArtifactException;
 
+   /**
+    * Resolve a list of channel metadata artifacts based on the coordinates.
+    * If the {@code ChannelMetadataCoordinate} contains non-null URL, that URL is returned.
+    * If the {@code ChannelMetadataCoordinate} contains non-null Maven coordinates, the Maven artifact will be resolved
+    * and a URL to it will be returned.
+    * If the Maven coordinates specify only groupId and artifactId, latest available version of matching Maven artifact
+    * will be resolved.
+    *
+    * The order of returned URLs is the same as order of coordinates.
+    *
+    * @param manifestCoords - list of ChannelMetadataCoordinate.
+    *
+    * @return a list of URLs to the metadata files
+    *
+    * @throws UnresolvedMavenArtifactException if any artifacts can not be resolved.
+    */
+   List<URL> resolveChannelMetadata(List<? extends ChannelMetadataCoordinate> manifestCoords) throws UnresolvedMavenArtifactException;
+
    default void close() {
    }
 
@@ -79,11 +101,11 @@ public interface MavenVersionsResolver extends Closeable {
     *
     * A client of this library is responsible to provide an implementation of the {@link Factory} interface.
     *
-    * The {@link #create()} method will be called once for every channel.
+    * The {@link #create(Collection)}} method will be called once for every channel.
     */
    interface Factory extends Closeable {
 
-      MavenVersionsResolver create();
+      MavenVersionsResolver create(Collection<Repository> repositories);
 
       default void close() {
       }

--- a/core/src/main/resources/org/wildfly/blocklist/v1.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/blocklist/v1.0.0/schema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://wildfly.org/channels/blocklist/v1.0.0/schema.json",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a blocklist resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "exclusions":{
+      "description": "Streams of excluded components",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "description": "GroupId of the blocklisted artifact. It must be a valid groupId (corresponding to a G of a Maven GAV)",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactId of the blocklisted artifact. It must be either a valid artifactId (corresponding to a A of a Maven GAV) or the * character to represent any artifactId",
+            "type": "string"
+          },
+          "versions": {
+            "description": "List of blocklisted versions of the artifact.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "groupId",
+          "artifactId",
+          "versions"
+        ]
+      }
+    }
+  }
+}

--- a/core/src/main/resources/org/wildfly/blocklist/v1.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/blocklist/v1.0.0/schema.json
@@ -9,8 +9,8 @@
       "type": "string",
       "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
     },
-    "exclusions":{
-      "description": "Streams of excluded components",
+    "blocks":{
+      "description": "Streams of blocked components",
       "type": "array",
       "minItems": 1,
       "items": {

--- a/core/src/main/resources/org/wildfly/channel/v2.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/channel/v2.0.0/schema.json
@@ -1,0 +1,146 @@
+{
+  "$id": "https://wildfly.org/channels/v2.0.0/schema.json",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion", "repositories"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a channel resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "name": {
+      "description": "Name of the channel. This is a one-line human-readable description of the channel",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the channel. This is a multi-lines human-readable description of the channel",
+      "type": "string"
+    },
+    "vendor": {
+      "description": "Vendor of the channel.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the vendor",
+          "type": "string"
+        },
+        "support": {
+          "description": "Support level provided by the vendor",
+          "type": "string",
+          "enum": [
+            "supported",
+            "tech-preview",
+            "community"
+          ]
+        }
+      },
+      "required": ["name", "support"]
+    },
+    "requires": {
+      "description": "Channels that are required by this channel.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minItems": 1,
+        "properties": {
+          "groupId": {
+            "description": "GroupID Maven coordinate of the channel",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactID Maven coordinate of the channel",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version Maven coordinate of the channel",
+            "type": "string"
+          }
+        },
+        "required": ["groupId", "artifactId"]
+      }
+    },
+    "repositories": {
+      "description": "Repositories the channel uses to resolve it's streams.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Id of the repository",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the repository",
+            "type": "string"
+          }
+        },
+        "required": ["id", "url"]
+      }
+    },
+    "manifest": {
+      "description": "Location of the channel's manifest",
+      "type": "object",
+      "properties": {
+        "gav": {
+          "description": "Maven coordinates of the manifest in format of 'groupId:artifactId[:version]'",
+          "type": "string"
+        },
+        "url": {
+          "description": "Static URL of the manifest file.",
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "gav"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "blocklist": {
+      "description": "Location of the channel's blocklist",
+      "type": "object",
+      "properties": {
+        "gav": {
+          "description": "Maven coordinates of the blocklist in format of 'groupId:artifactId[:version]'",
+          "type": "string"
+        },
+        "url": {
+          "description": "Static URL of the blocklist file.",
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "gav"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
+    },
+    "resolves-if-no-stream": {
+      "description": "Strategy for resolving artifact versions if it is not listed in streams.",
+      "type": "string",
+      "enum": [
+        "latest",
+        "maven-latest",
+        "maven-release",
+        "none",
+        "original"
+      ]
+    }
+  }
+}

--- a/core/src/main/resources/org/wildfly/channel/v2.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/channel/v2.0.0/schema.json
@@ -61,7 +61,7 @@
       }
     },
     "repositories": {
-      "description": "Repositories the channel uses to resolve it's streams.",
+      "description": "Repositories the channel uses to resolve its streams.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -83,19 +83,33 @@
       "description": "Location of the channel's manifest",
       "type": "object",
       "properties": {
-        "gav": {
-          "description": "Maven coordinates of the manifest in format of 'groupId:artifactId[:version]'",
-          "type": "string"
+        "maven": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "description": "GroupID Maven coordinate of the manifest",
+              "type": "string"
+            },
+            "artifactId": {
+              "description": "ArtifactID Maven coordinate of the manifest",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version Maven coordinate of the manifest",
+              "type": "string"
+            }
+          },
+          "required": ["groupId", "artifactId"]
         },
         "url": {
-          "description": "Static URL of the manifest file.",
+          "description": "URL of the manifest file.",
           "type": "string"
         }
       },
       "oneOf": [
         {
           "required": [
-            "gav"
+            "maven"
           ]
         },
         {
@@ -109,19 +123,33 @@
       "description": "Location of the channel's blocklist",
       "type": "object",
       "properties": {
-        "gav": {
-          "description": "Maven coordinates of the blocklist in format of 'groupId:artifactId[:version]'",
-          "type": "string"
+        "maven": {
+          "type": "object",
+          "properties": {
+            "groupId": {
+              "description": "GroupID Maven coordinate of the blocklist",
+              "type": "string"
+            },
+            "artifactId": {
+              "description": "ArtifactID Maven coordinate of the blocklist",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version Maven coordinate of the blocklist",
+              "type": "string"
+            }
+          },
+          "required": ["groupId", "artifactId"]
         },
         "url": {
-          "description": "Static URL of the blocklist file.",
+          "description": "URL of the blocklist file.",
           "type": "string"
         }
       },
       "oneOf": [
         {
           "required": [
-            "gav"
+            "maven"
           ]
         },
         {
@@ -131,8 +159,8 @@
         }
       ]
     },
-    "resolves-if-no-stream": {
-      "description": "Strategy for resolving artifact versions if it is not listed in streams.",
+    "resolve-if-no-stream": {
+      "description": "Strategy for resolving artifact versions if it is not listed in streams. If not specified, 'original' strategy is used.",
       "type": "string",
       "enum": [
         "latest",

--- a/core/src/main/resources/org/wildfly/manifest/v1.0.0/schema.json
+++ b/core/src/main/resources/org/wildfly/manifest/v1.0.0/schema.json
@@ -1,0 +1,56 @@
+{
+  "$id": "https://wildfly.org/manifests/v1.0.0/schema.json",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a manifest resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "name": {
+      "description": "Name of the manifest. This is a one-line human-readable description of the manifest",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the manifest. This is a multi-lines human-readable description of the manifest",
+      "type": "string"
+    },
+    "streams":{
+      "description": "Streams of components that are provided by this channel",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "description": "GroupId of the stream. It must be a valid groupId (corresponding to a G of a Maven GAV)",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactId of the stream. It must be either a valid artifactId (corresponding to a A of a Maven GAV) or the * character to represent any artifactId",
+            "type": "string"
+          },
+          "version" : {
+            "description": "Version of the stream. This must be either a single version. Only one of version, versionPattern must be set.",
+            "type": "string"
+          },
+          "versionPattern" : {
+            "description": "VersionPattern of the stream. This is a regular expression that matches any version from this stream. Only one of version, versionPattern must be set.",
+            "type": "string"
+          }
+        },
+        "required": ["groupId", "artifactId"],
+        "oneOf": [
+          {
+            "required": ["version"]
+          },
+          {
+            "required": ["versionPattern"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/wildfly/channel/ChannelManifestMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelManifestMapperTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.channel;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ChannelManifestMapperTestCase {
+
+    @Test
+    public void testWriteReadChannel() throws Exception {
+        final ChannelManifest manifest = new ChannelManifest("test_name", "test_desc", Collections.emptyList());
+        final String yaml = ChannelManifestMapper.toYaml(manifest);
+
+        final ChannelManifest manifest1 = ChannelManifestMapper.fromString(yaml);
+        assertEquals("test_desc", manifest1.getDescription());
+    }
+
+    @Test
+    public void testWriteMultipleChannels() throws Exception {
+        final ChannelRequirement req = new ChannelRequirement("org", "foo", "1.2.3");
+        final Stream stream1 = new Stream("org.bar", "example", "1.2.3");
+        final Stream stream2 = new Stream("org.bar", "other-example", Pattern.compile("\\.*"));
+        final ChannelManifest manifest1 = new ChannelManifest("test_name_1", "test_desc", Arrays.asList(stream1, stream2));
+        final ChannelManifest manifest2 = new ChannelManifest("test_name_2", "test_desc", Collections.emptyList());
+        final String yaml1 = ChannelManifestMapper.toYaml(manifest1);
+        final String yaml2 = ChannelManifestMapper.toYaml(manifest2);
+
+        System.out.println(yaml1);
+        System.out.println(yaml2);
+
+        final ChannelManifest m1 = ChannelManifestMapper.fromString(yaml1);
+        assertEquals(manifest1.getName(), m1.getName());
+        assertEquals(2, m1.getStreams().size());
+        assertEquals("example", m1.getStreams().stream().findFirst().get().getArtifactId());
+        final ChannelManifest m2 = ChannelManifestMapper.fromString(yaml2);
+        assertEquals(manifest2.getName(), m2.getName());
+        assertEquals(0, m2.getStreams().size());
+    }
+
+    @Test
+    public void testReadChannelWithUnknownProperties() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/manifest-with-unknown-properties.yaml");
+
+        Channel channel = ChannelMapper.from(file);
+        assertNotNull(channel);
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -18,13 +18,10 @@ package org.wildfly.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
 
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +29,11 @@ public class ChannelMapperTestCase {
 
     @Test
     public void testWriteReadChannel() throws Exception {
-        final Channel channel = new Channel("test_name", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final Channel channel = new Channel("test_name", "test_desc",
+                new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
+                Collections.emptyList(),
+                List.of(new Repository("test", "https://test.org/repository")),
+                new ChannelManifestCoordinate("test.channels", "channel"));
         final String yaml = ChannelMapper.toYaml(channel);
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);
@@ -42,10 +43,14 @@ public class ChannelMapperTestCase {
     @Test
     public void testWriteMultipleChannels() throws Exception {
         final ChannelRequirement req = new ChannelRequirement("org", "foo", "1.2.3");
-        final Stream stream1 = new Stream("org.bar", "example", "1.2.3");
-        final Stream stream2 = new Stream("org.bar", "other-example", Pattern.compile("\\.*"));
-        final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Arrays.asList(req), Arrays.asList(stream1, stream2));
-        final Channel channel2 = new Channel("test_name_2", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY), Collections.emptyList(), Collections.emptyList());
+        final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
+                List.of(req),
+                List.of(new Repository("test", "https://test.org/repository")),
+                new ChannelManifestCoordinate("test.channels", "channel"));
+        final Channel channel2 = new Channel("test_name_2", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
+                Collections.emptyList(),
+                List.of(new Repository("test", "https://test.org/repository")),
+                new ChannelManifestCoordinate(new URL("http://test.channels/channels")));
         final String yaml = ChannelMapper.toYaml(channel1, channel2);
 
         System.out.println(yaml);

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -33,7 +33,8 @@ public class ChannelMapperTestCase {
                 new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
                 Collections.emptyList(),
                 List.of(new Repository("test", "https://test.org/repository")),
-                new ChannelManifestCoordinate("test.channels", "channel"));
+                new ChannelManifestCoordinate("test.channels", "channel"),
+                Channel.NoStreamStrategy.NONE);
         final String yaml = ChannelMapper.toYaml(channel);
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);
@@ -46,11 +47,13 @@ public class ChannelMapperTestCase {
         final Channel channel1 = new Channel("test_name_1", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
                 List.of(req),
                 List.of(new Repository("test", "https://test.org/repository")),
-                new ChannelManifestCoordinate("test.channels", "channel"));
+                new ChannelManifestCoordinate("test.channels", "channel"),
+                Channel.NoStreamStrategy.NONE);
         final Channel channel2 = new Channel("test_name_2", "test_desc", new Vendor("test_vendor_name", Vendor.Support.COMMUNITY),
                 Collections.emptyList(),
                 List.of(new Repository("test", "https://test.org/repository")),
-                new ChannelManifestCoordinate(new URL("http://test.channels/channels")));
+                new ChannelManifestCoordinate(new URL("http://test.channels/channels")),
+                Channel.NoStreamStrategy.NONE);
         final String yaml = ChannelMapper.toYaml(channel1, channel2);
 
         System.out.println(yaml);

--- a/core/src/test/java/org/wildfly/channel/ChannelSessionTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelSessionTestCase.java
@@ -82,16 +82,21 @@ public class ChannelSessionTestCase {
     }
 
     public static List<Channel> mockChannel(MavenVersionsResolver resolver, Path tempDir, String... manifests) throws IOException {
+        return mockChannel(resolver, tempDir, null, manifests);
+    }
+
+    public static List<Channel> mockChannel(MavenVersionsResolver resolver, Path tempDir, Channel.NoStreamStrategy strategy, String... manifests) throws IOException {
         List<Channel> channels = new ArrayList<>();
         for (int i = 0; i < manifests.length; i++) {
             channels.add(new Channel(null, null, null, null,
                     emptyList(),
-                    new ChannelManifestCoordinate("org.channels", "channel" + i, "1.0.0")));
+                    new ChannelManifestCoordinate("org.channels", "channel" + i, "1.0.0"),
+                    strategy));
             String manifest = manifests[i];
             Path manifestFile = Files.writeString(tempDir.resolve("manifest" + i +".yaml"), manifest);
 
             when(resolver.resolveChannelMetadata(eq(List.of(new ChannelManifestCoordinate("org.channels", "channel" + i, "1.0.0")))))
-                .thenReturn(List.of(manifestFile.toUri().toURL()));
+                    .thenReturn(List.of(manifestFile.toUri().toURL()));
         }
         return channels;
     }
@@ -202,7 +207,7 @@ public class ChannelSessionTestCase {
         when(factory.create(any())).thenReturn(resolver);
         when(resolver.resolveArtifact("org.bar", "bar", null, null, "1.0.0.Final")).thenReturn(resolvedArtifactFile);
 
-        final List<Channel> channels = mockChannel(resolver, tempDir, manifest);
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.NONE, manifest);
 
         try (ChannelSession session = new ChannelSession(channels, factory)) {
 
@@ -412,6 +417,201 @@ public class ChannelSessionTestCase {
             MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "foo", null, null, "1.0.0.Final");
             assertNotNull(resolvedArtifact);
             assertEquals("26.0.0.Final", resolvedArtifact.getVersion());
+        }
+    }
+
+    @Test
+    public void testChannelWithOriginalStrategy() throws Exception {
+        String manifest = "schemaVersion: " + ChannelManifestMapper.CURRENT_SCHEMA_VERSION + "\n" +
+                           "streams:\n" +
+                           "  - groupId: org.foo\n" +
+                           "    artifactId: foo\n" +
+                           "    version: \"25.0.0.Final\"";
+
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.ORIGINAL, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("1.0.0.Final"))).thenReturn(resolvedArtifactFile);
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "bar", null, null, "1.0.0.Final");
+            assertNotNull(resolvedArtifact);
+            assertEquals("1.0.0.Final", resolvedArtifact.getVersion());
+        }
+    }
+
+    @Test
+    public void testChannelWithLatestStrategy() throws Exception {
+        String manifest = "schemaVersion: " + ChannelManifestMapper.CURRENT_SCHEMA_VERSION + "\n" +
+                                                      "streams:\n" +
+                                                      "  - groupId: org.foo\n" +
+                                                      "    artifactId: foo\n" +
+                                                      "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.LATEST, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("25.0.2.Final"))).thenReturn(resolvedArtifactFile);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of("25.0.2.Final", "25.0.1.Final", "25.0.0.Final"));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final");
+            assertNotNull(resolvedArtifact);
+            assertEquals("25.0.2.Final", resolvedArtifact.getVersion());
+        }
+    }
+
+    @Test
+    public void testChannelWithLatestStrategyNoArtifact() throws Exception {
+        String manifest = "schemaVersion: " + ChannelManifestMapper.CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: foo\n" +
+                          "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.LATEST, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of());
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            Assertions.assertThrows(UnresolvedMavenArtifactException.class, () ->
+                session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final")
+            );
+        }
+    }
+
+    @Test
+    public void testChannelWithLatestStrategyWithVersionPattern() throws Exception {
+        String manifest = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: bar\n" +
+                          "    versionPattern: \".*Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.LATEST, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of("1.0.0"));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            Assertions.assertThrows(UnresolvedMavenArtifactException.class, () ->
+               session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final")
+            );
+        }
+    }
+
+    @Test
+    public void testChannelWithMavenReleaseStrategy() throws Exception {
+        String manifest = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: foo\n" +
+                          "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.MAVEN_RELEASE, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.getMetadataReleaseVersion(eq("org.foo"), eq("bar"))).thenReturn("25.0.1.Final");
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("25.0.1.Final"))).thenReturn(resolvedArtifactFile);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of("25.0.1.Final", "25.0.0.Final"));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final");
+            assertEquals("25.0.1.Final", resolvedArtifact.getVersion());
+        }
+    }
+
+    @Test
+    public void testChannelWithMavenLatestStrategy() throws Exception {
+        String manifest = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: foo\n" +
+                          "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.MAVEN_LATEST, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.getMetadataLatestVersion(eq("org.foo"), eq("bar"))).thenReturn("25.0.1.Final");
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("25.0.1.Final"))).thenReturn(resolvedArtifactFile);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of("25.0.1.Final", "25.0.0.Final"));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final");
+            assertEquals("25.0.1.Final", resolvedArtifact.getVersion());
+        }
+    }
+
+    @Test
+    public void testChannelWithStrictStrategy() throws Exception {
+        String manifest = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: foo\n" +
+                          "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.NONE, manifest);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("25.0.1.Final"))).thenReturn(resolvedArtifactFile);
+        when(resolver.getAllVersions("org.foo", "bar", null, null)).thenReturn(Set.of("25.0.1.Final", "25.0.0.Final"));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            Assertions.assertThrows(UnresolvedMavenArtifactException.class, () ->
+               session.resolveMavenArtifact("org.foo", "bar", null, null, "25.0.1.Final")
+            );
+        }
+    }
+
+    @Test
+    public void testChannelWithDefaultStrategy() throws Exception {
+        String manifest = "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                          "streams:\n" +
+                          "  - groupId: org.foo\n" +
+                          "    artifactId: foo\n" +
+                          "    version: \"25.0.0.Final\"";
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        when(factory.create(any())).thenReturn(resolver);
+        when(resolver.resolveArtifact(eq("org.foo"), eq("bar"), eq(null), eq(null), eq("1.0.0.Final"))).thenReturn(resolvedArtifactFile);
+
+        final List<Channel> channels = mockChannel(resolver, tempDir, Channel.NoStreamStrategy.ORIGINAL, manifest);
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            MavenArtifact resolvedArtifact = session.resolveMavenArtifact("org.foo", "bar", null, null, "1.0.0.Final");
+            assertNotNull(resolvedArtifact);
+            assertEquals("1.0.0.Final", resolvedArtifact.getVersion());
         }
     }
 

--- a/core/src/test/java/org/wildfly/channel/StreamResolverTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/StreamResolverTestCase.java
@@ -19,7 +19,7 @@ package org.wildfly.channel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
+import static org.wildfly.channel.ChannelManifestMapper.CURRENT_SCHEMA_VERSION;
 
 import java.util.Optional;
 
@@ -41,24 +41,24 @@ public class StreamResolverTestCase {
                 "  - groupId: io.undertow\n" +
                 "    artifactId: undertow-servlet\n" +
                 "    version: 3.0.2.Final";
-        Channel channel = ChannelMapper.fromString(yamlContent).get(0);
+        ChannelManifest manifest = ChannelManifestMapper.fromString(yamlContent);
 
-        Optional<Stream> stream = channel.findStreamFor("io.undertow", "undertow-core");
+        Optional<Stream> stream = manifest.findStreamFor("io.undertow", "undertow-core");
         assertTrue(stream.isPresent());
         assertEquals("io.undertow", stream.get().getGroupId());
         assertEquals("undertow-core", stream.get().getArtifactId());
 
-        stream = channel.findStreamFor("io.undertow", "undertow-servlet");
+        stream = manifest.findStreamFor("io.undertow", "undertow-servlet");
         assertTrue(stream.isPresent());
         assertEquals("io.undertow", stream.get().getGroupId());
         assertEquals("undertow-servlet", stream.get().getArtifactId());
 
-        stream = channel.findStreamFor("io.undertow", "undertow-websockets-jsr");
+        stream = manifest.findStreamFor("io.undertow", "undertow-websockets-jsr");
         assertTrue(stream.isPresent());
         assertEquals("io.undertow", stream.get().getGroupId());
         assertEquals("*", stream.get().getArtifactId());
 
-        stream = channel.findStreamFor("org.example", "foo");
+        stream = manifest.findStreamFor("org.example", "foo");
         assertFalse(stream.isPresent());
 
     }

--- a/core/src/test/java/org/wildfly/channel/mapping/ChannelManifestTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/mapping/ChannelManifestTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.channel.mapping;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestMapper;
+import org.wildfly.channel.Stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wildfly.channel.ChannelManifestMapper.CURRENT_SCHEMA_VERSION;
+
+public class ChannelManifestTestCase {
+
+    @Test
+    public void nonExistingManifestTest() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("this-manifest-does-not-exist.yaml");
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            ChannelManifestMapper.from(file);
+        });
+    }
+
+    @Test()
+    public void emptyManifestTest() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/empty-channel.yaml");
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            ChannelManifestMapper.from(file);
+        });
+    }
+
+    @Test()
+    public void multipleManifestsTest() throws IOException {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/multiple-manifests.yaml");
+
+        try (InputStream in = file.openStream())
+        {
+            byte[] bytes = in.readAllBytes();
+            String content = new String(bytes, Charset.defaultCharset());
+            ChannelManifest manifest = ChannelManifestMapper.fromString(content);
+            assertEquals("Channel for WildFly 27", manifest.getName());
+        }
+    }
+
+    @Test
+    public void simpleManifestTest() throws MalformedURLException {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        URL file = tccl.getResource("channels/simple-manifest.yaml");
+
+        ChannelManifest manifest = ChannelManifestMapper.from(file);
+
+        assertEquals("My Channel", manifest.getName());
+        assertEquals("This is my manifest\n" +
+                "with my stuff", manifest.getDescription());
+
+        Collection<Stream> streams = manifest.getStreams();
+        assertEquals(1, streams.size());
+        Stream stream = streams.iterator().next();
+        assertEquals("org.wildfly", stream.getGroupId());
+        assertEquals("wildfly-ee-galleon-pack", stream.getArtifactId());
+        assertEquals("26.0.0.Final", stream.getVersion());
+    }
+
+    @Test
+    public void manifestWithoutStreams() {
+        ChannelManifest manifest = ChannelManifestMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "name: My Channel\n" +
+                "description: |-\n" +
+                "  This is my manifest\n" +
+                "  with no stream");
+
+        assertTrue(manifest.getStreams().isEmpty());
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/mapping/ChannelTestCase.java
@@ -18,8 +18,7 @@ package org.wildfly.channel.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
+import static org.wildfly.channel.ChannelManifestMapper.CURRENT_SCHEMA_VERSION;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.wildfly.channel.Channel;
 import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.ChannelRequirement;
-import org.wildfly.channel.Stream;
 import org.wildfly.channel.Vendor;
 
 public class ChannelTestCase {
@@ -91,26 +89,6 @@ public class ChannelTestCase {
 
         Collection<ChannelRequirement> requires = channel.getChannelRequirements();
         assertEquals(0, requires.size());
-
-        Collection<Stream> streams = channel.getStreams();
-        assertEquals(1, streams.size());
-        Stream stream = streams.iterator().next();
-        assertEquals("org.wildfly", stream.getGroupId());
-        assertEquals("wildfly-ee-galleon-pack", stream.getArtifactId());
-        assertEquals("26.0.0.Final", stream.getVersion());
-    }
-
-    @Test
-    public void channelWithoutStreams() {
-        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
-                "name: My Channel\n" +
-                "description: |-\n" +
-                "  This is my channel\n" +
-                "  with no stream");
-        assertEquals(1, channels.size());
-        Channel channel = channels.get(0);
-
-        assertTrue(channel.getStreams().isEmpty());
     }
 
     @Test

--- a/core/src/test/resources/channels/2nd-level-requiring-channel.yaml
+++ b/core/src/test/resources/channels/2nd-level-requiring-channel.yaml
@@ -1,13 +1,14 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 name: 2nd level requiring channel
 requires:
   - groupId: org.foo
     artifactId: required-channel
     version: 2.0.0.Final
-streams:
-  - groupId: org.example
-    artifactId: foo-bar
-    version: 1.0.0.Final
-  - groupId: org.example
-    artifactId: im-only-in-second-level
-    version: 1.0.0.Final
+manifest:
+  maven:
+    groupId: test.channels
+    artifactId: required-2nd-level-manifest
+    version: 1.0.0
+repositories:
+  - id: test
+    url: test-repository

--- a/core/src/test/resources/channels/2nd-level-requiring-manifest.yaml
+++ b/core/src/test/resources/channels/2nd-level-requiring-manifest.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+name: 2nd level requiring manifest
+streams:
+  - groupId: org.example
+    artifactId: foo-bar
+    version: 1.0.0.Final
+  - groupId: org.example
+    artifactId: im-only-in-second-level
+    version: 1.0.0.Final

--- a/core/src/test/resources/channels/channel-with-unknown-properties.yaml
+++ b/core/src/test/resources/channels/channel-with-unknown-properties.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 name: My Channel
 description: |-
   This is my channel
@@ -7,8 +7,11 @@ vendor:
   name: My Vendor
   support: community
 foo: not an known property
-streams:
-  - groupId: org.wildfly
-    artifactId: wildfly-ee-galleon-pack
-    version: 26.0.0.Final
-    bar: not a known property
+manifest:
+  maven:
+    groupId: test.channels
+    artifactId: channel
+  bar: not a known property
+repositories:
+  - id: test
+    url: https://test.org/repository

--- a/core/src/test/resources/channels/manifest-with-unknown-properties.yaml
+++ b/core/src/test/resources/channels/manifest-with-unknown-properties.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "1.0.0"
+name: My Manifest
+description: |-
+  This is my manifest
+  with properties that are not defined in the schema
+foo: not an known property
+streams:
+  - groupId: org.wildfly
+    artifactId: wildfly-ee-galleon-pack
+    version: 26.0.0.Final
+    bar: not a known property

--- a/core/src/test/resources/channels/multiple-manifests.yaml
+++ b/core/src/test/resources/channels/multiple-manifests.yaml
@@ -1,0 +1,6 @@
+---
+schemaVersion:  "1.0.0"
+name: Channel for WildFly 27
+---
+schemaVersion:  "1.0.0"
+name: Channel for WildFly 28

--- a/core/src/test/resources/channels/required-channel-2.yaml
+++ b/core/src/test/resources/channels/required-channel-2.yaml
@@ -1,6 +1,10 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 name: My Required Channel
-streams:
-  - groupId: org.example
-    artifactId: foo-bar
-    version: 2.0.0.Final
+manifest:
+  maven:
+    groupId: "test.channels"
+    artifactId: "required-manifest-2"
+    version: "1.0.0"
+repositories:
+  - id: test
+    url: test-repository

--- a/core/src/test/resources/channels/required-channel.yaml
+++ b/core/src/test/resources/channels/required-channel.yaml
@@ -1,9 +1,10 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 name: My Required Channel
-streams:
-  - groupId: org.example
-    artifactId: foo-bar
-    version: 1.2.0.Final
-  - groupId: org.example
-    artifactId: im-only-in-required-channel
-    version: 1.0.0.Final
+manifest:
+  maven:
+    groupId: "test.channels"
+    artifactId: "required-manifest"
+    version: "1.0.0"
+repositories:
+  - id: test
+    url: test-repository

--- a/core/src/test/resources/channels/required-manifest-2.yaml
+++ b/core/src/test/resources/channels/required-manifest-2.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "1.0.0"
+name: My Required Manifest 2
+streams:
+  - groupId: org.example
+    artifactId: foo-bar
+    version: 2.0.0.Final

--- a/core/src/test/resources/channels/required-manifest.yaml
+++ b/core/src/test/resources/channels/required-manifest.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+name: My Required Manifest
+streams:
+  - groupId: org.example
+    artifactId: foo-bar
+    version: 1.2.0.Final
+  - groupId: org.example
+    artifactId: im-only-in-required-channel
+    version: 1.0.0.Final

--- a/core/src/test/resources/channels/simple-channel.yaml
+++ b/core/src/test/resources/channels/simple-channel.yaml
@@ -1,4 +1,4 @@
-schemaVersion: "1.0.0"
+schemaVersion: "2.0.0"
 name: My Channel
 description: |-
   This is my channel
@@ -6,7 +6,10 @@ description: |-
 vendor:
   name: My Vendor
   support: community
-streams:
-  - groupId: org.wildfly
-    artifactId: wildfly-ee-galleon-pack
-    version: 26.0.0.Final
+repositories:
+- id: test
+  url: test-repository
+manifest:
+  maven:
+    groupId: org.test
+    artifactId: test-manifest

--- a/core/src/test/resources/channels/simple-manifest.yaml
+++ b/core/src/test/resources/channels/simple-manifest.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "1.0.0"
+name: My Channel
+description: |-
+  This is my manifest
+  with my stuff
+streams:
+  - groupId: org.wildfly
+    artifactId: wildfly-ee-galleon-pack
+    version: 26.0.0.Final

--- a/doc/examples/channel.adoc
+++ b/doc/examples/channel.adoc
@@ -1,0 +1,161 @@
+# Example channels
+
+## Simple channel definition
+
+Open channel uses streams with version patterns and resolve-if-no-stream to define content.
+
+The first step to create a channel is the definition file:
+
+[source, yaml, title="test-channel.yaml"]
+----
+schemaVersion: "2.0.0"
+name: "test-channel"  #<1>
+resolve-if-no-stream: latest #<2>
+repositories: #<3>
+  - id: "central"
+    url: "https://repo1.maven.org/maven2/"
+----
+<1> human readable channel name
+<2> `latest` strategy means that if channel cannot find a stream matching the requested artifact, it will attempt to find the latest version in its repositories
+<3> the repository channel is allowed to use to resolve requested artifacts.
+
+In this form channel will be able to resolve any artifact in `central` repository. It will always return the "latest" available version according to rules defined in spec.
+
+## Limiting available versions
+
+In most channels, the version resolution will need to be limited in some way. Channels provide a number of mechanism to achieve that.
+
+### Streams with concrete versions
+
+If the channel should only allow one, specific version of artifact to be resolved, a new stream can be added to the manifest:
+
+[source, yaml, title="test-manifest.yaml"]
+----
+schemaVersion: "1.0.0"
+name: "test-manifest"
+streams: #<1>
+- groupId: "org.test"
+  artifactId: "artifact-one"
+  version: "1.2.3.Final"
+----
+<1> a list of curated artifact streams
+
+This manifest needs to referenced in the Channel. Let's say that to make it available, we publish it in an internal Maven repository with classifier `manifest` - e.g. as `org.test.channel:test:manifest:yaml:1.0.0.Final`. The channel definition will have to modified as follows:
+
+[source, yaml, title="test-channel.yaml"]
+----
+schemaVersion: "2.0.0"
+name: "test-channel"
+resolve-if-no-stream: latest
+manifest:
+  maven: #<1>
+    groupId: "org.test.channel"
+    artifactId: "test"
+repositories:
+  - id: "central"
+    url: "https://repo1.maven.org/maven2/"
+  - id: "internal" #<2>
+    url: "https://internal.org/repository"
+----
+<1> Instruct the channel to resolve the latest available version of `org.test.channel:test:manifest:yaml`
+<2> Add an internal maven repository to the channel
+
+Now, when resolving artifact `org.test:artifact-one`, the channel will always return version `1.2.3.Final`.
+
+For anny other artifact, the latest available version will still be resolved. Note that since a new repository was added to the channel, the artifacts will be resolved in both `central` and `internal` repository.
+
+### Streams with version patterns
+
+Sometimes the artifact version needs to be limited to a certain version range - e.g. based on a minor or a version suffix. In such cases, it might be possible to utilize streams with `versionPattern`:
+
+[source, yaml, title="test-manifest.yaml"]
+----
+schemaVersion: "1.0.0"
+name: "test-manifest"
+streams:
+  - groupId: "org.test"
+    artifactId: "artifact-one"
+    version: "1.2.3.Final"
+  - groupId: "org.test"
+    artifactId: "artifact-two"
+    versionPattern: "1.2.*" #<1>
+...
+----
+<1> allow only versions starting with "1.2" for "artifact-two"
+
+The modified `test-manifest.yaml` needs to be published with a new version - e.g. as `org.test.channel:test:manifest:yaml:1.0.1.Final`. The channel will automatically resolve the latest available version of the manifest.
+
+Assuming the Maven repositories contain two versions of the `artifact-two` - `1.2.1.Final` and `1.3.0.Final`. Because the stream allows only versions matching `1.2.*` pattern, the former version will return, even though `1.3.0.Final` would normally be considered "later".
+
+If a new version `1.2.2.Final` is added to the repository, the Channel will resolve it instead as it's considered "later" then `1.2.1.Final` and matches the version pattern.
+
+### Block versions
+
+Blocklist allows to exclude a concrete version of an artifact from resolution while maintaining the "latest" resolution strategy. To block an artifact version we need to create a new file called `test-blocklist.yaml`:
+
+[source, yaml, title="test-blocklist.yaml"]
+----
+schemaVersion: "1.0.0"
+name: "test-blocklist"
+blocks:
+  - groupId: "org.test"
+    artifactId: "artifact-three" #<1>
+    version: #<1>
+    - "1.0.1.Final"
+...
+----
+<1> if the block rules should apply to all artifact without a `groupId` a wildcard `*` can be used
+<2> the blocks list can include multiple versions of artifact
+
+Again the new file needs to published in a Maven repository, this time with classifier `blocklist` - e.g. as `org.test.channel:test:blocklist:yaml:1.0.1.Final`, and included in the channel definition:
+
+[source, yaml, title="test-channel.yaml"]
+----
+schemaVersion: "2.0.0"
+name: "test-channel"
+resolve-if-no-stream: latest
+manifest:
+  maven:
+    groupId: "org.test.channel"
+    artifactId: "test"
+blocklist:
+  maven: #<1>
+    groupId: "org.test.channel"
+    artifactId: "test"
+repositories:
+  - id: "central"
+    url: "https://repo1.maven.org/maven2/"
+  - id: "internal"
+    url: "https://internal.org/repository"
+----
+<1> added blocklist definition
+
+Let's say the Maven repositories currently contain versions 1.0.0.Final and 1.0.1.Final of `org.test.artifact-three`. When `artifact-three` is resolved from the Channel, the `1.0.1.Final` version will be blocked, and instead `1.0.0.Final` will be used.
+
+When a new version, `1.0.3.Final`, is made available, the channel will instead resolve that version and the blocklist will have no effect.
+
+## Fix manifest and blocklist versions
+
+So far the channel has been using the latest available versions of manifest and blocklist. If required this can be changed to either use a specific Maven version or a file URL:
+
+[source, yaml, title="test-channel.yaml"]
+----
+schemaVersion: "2.0.0"
+name: "test-channel"
+resolve-if-no-stream: latest
+manifest:
+  maven:
+    groupId: "org.test.channel"
+    artifactId: "test"
+    version: "1.0.1.Final" #<1>
+blocklist:
+  url: "http://internal.org/test-blocklist.yaml" #<2>
+repositories:
+  - id: "central"
+    url: "https://repo1.maven.org/maven2/"
+  - id: "internal"
+    url: "https://internal.org/repository"
+----
+<1> The channel will always use version `1.0.1.Final` of the manifest, even if newer verisons are available.
+<2> The channel will download the blocklist from `http://internal.org/test-blocklist.yaml` instead of resolving it from Maven repositories.
+

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -44,6 +44,8 @@ Backwards compatibility is only guaranteed inside a single channel. If an instal
 
 Channel combines a Channel Manifest defining content of channel, one or more Repositories from which the content can be resolved and an optional Blocklist Manifest.
 
+
+### Channel definition
 A channel is composed of several fields:
 
 * An optional `name` that is a human-readable one-line description of the channel (`Channel for WildFly 27`)
@@ -62,24 +64,29 @@ Each element is composed of:
 * A collection of `repositories` that defines repositories associated with the channel. Only listed repositories are used to resolve channel's components. Each repository is composed of:
 ** A required `id` that defines the repository name used in Maven cache
 ** A required `url` pointing to a default Maven repository
-* Optional `manifest` corresponding to the Channel Manifest artefact. Channel Manifest is used to define streams available in the channel.
+* Optional `manifest` corresponding to the Channel Manifest artifact. Channel Manifest is used to define streams available in the channel.
 ** One of the following, mutually exclusive fields, used to resolve the Channel Manifest:
-*** `gav` corresponds to Maven coordinates of the Manifest. It can either use format of `groupId:artifactId` (resulting in the latest available version being used) or `groupId:artifactId:version` (resulting in concrete version being used)
-*** `url` corresponding to a static URL where the manifest file can be found.
-* Optional `blocklist` corresponding to the Blocklist artefact. Blocklist is used to define versions of artifacts excluded from a channel.
+*** `maven` corresponds to Maven coordinates of the Manifest. It's composed of:
+**** Mandatory `groupId` and `artifactId` elements that are the Maven coordinates of the manifest.
+**** Optional `version` to stick to a given manifest version (instead of requiring the latest version of that manifest). In the absence of this `version`, the latest version of the manifest will be determined based on the Maven repository metadata (see <<Component Version>>).
+*** `url` corresponding to a URL where the manifest file can be found.
+* Optional `blocklist` corresponding to the Blocklist artifact. Blocklist is used to define versions of artifacts excluded from a channel.
 ** One of the following, mutually exclusive fields, used to resolve the Blocklist:
-*** `gav` corresponds to Maven coordinates of the Manifest. It can either use format of `groupId:artifactId` (resulting in the latest available version being used) or `groupId:artifactId:version` (resulting in concrete version being used)
-*** `url` corresponding to a static URL where the manifest file can be found.
-* An optional `resolves-if-no-stream` that defines strategy for version resolution if the artifact has not been found in the `streams` collection. Allowed values are:
+*** `maven` corresponds to Maven coordinates of the Blocklist. It's composed of:
+**** Mandatory `groupId` and `artifactId` elements that are the Maven coordinates of the blocklist.
+**** Optional `version` to stick to a given blocklist version (instead of requiring the latest version of that blocklist). In the absence of this `version`, the latest version of the blocklist will be determined based on the Maven repository metadata (see <<Component Version>>).
+*** `url` corresponding to a URL where the blocklist file can be found.
+* An optional `resolve-if-no-stream` that defines strategy for version resolution if the artifact has not been found in the `streams` collection or if the channel didn't declare a manifest. Allowed values are:
 ** `original` - fallback to the `baseVersion` provided when querying the channel. Default value if no strategy is provided.
-** `latest` - use the latest version found in the Maven repositories
+** `latest` - use the latest version found in the Maven repositories (using mechanism described in <<Component Version>>)
 ** `maven-latest` - a version marked as `latest` in the Maven metadata
 ** `maven-release` - a version marked as `release` in the Maven metadata
 ** `none` - do not attempt to resolve versions of artifact not listed in the `streams` collection
 
+### Manifest definition
 A Channel Manifest is composed of following fields:
 
-* An optional `name` that is a human-readable one-line description of the channel (`Channel for WildFly 27`)
+* An optional `name` that is a human-readable one-line description of the channel (`manifest for WildFly 27`)
 * An optional `description` that provides human-readable description of the channel
 * A collection of `streams` that defines all the components installable from this channel. Each stream is composed of:
 ** A required `groupId` that corresponds to Maven GroupId to pull artifacts (it is not allowed to specify `*` for the groupId).
@@ -88,10 +95,11 @@ A Channel Manifest is composed of following fields:
 *** `versionPattern` corresponds to a Pattern through which the available versions are matched (e.g. `2\.2\..*`)
 *** `version` corresponds to a single version (e.g. `2.2.Final`)
 
-A channel does not define the Maven repositories that contain the resolved Maven artifacts from any of its streams.
-It is up to the provisioning tooling to properly configure the required Maven repositories.
-
-A channel does not provide any default streams.
+### Blocklist definition
+* A collection of `blocks` that defines all the component versions excluded from version resolution. Each exclusion is composed of:
+** A required `groupId` that corresponds to Maven GroupId of the excluded artifacts (it is not allowed to specify `*` for the groupId).
+** A required `artifactId` that corresponds to Maven ArtifactId of the excluded artifacts. Special syntax `*` can be used to match _any_ artifactId.
+** A required list of `versions` corresponding to excluded version (e.g. `[2.2.Final, 2.2.1.Final]`)
 
 ## Channel Schema
 
@@ -118,11 +126,11 @@ Creating a channel corresponds to the creation of the above files.
 A channel may be “published” so that it can be read (or downloaded) by WildFly provisioning tooling.
 Channels are published as a Maven artifact with the classifier `channel` and extension/type `yaml`.
 
-Manifest and Blocklist files must be "published" in one of the repositories defined in the Channel so that the Channel is able to resolve them.
+If the Channel uses maven coordinates to reference Manifest and/or Blocklist, those files must be "published" in one of the repositories defined in the Channel so that the Channel is able to resolve them. Otherwise, those files must be made available at the URLs defined by the Channel.
 
-Manifests are published as Maven artifacts with the classifier `manifest` and extension/type `yaml`.
+When manifests are published as Maven artifacts, they must use the classifier `manifest` and extension/type `yaml`.
 
-Blocklists are published as Maven artifacts with the classifier `blocklist` and extension/type `yaml`. The manifest needs to be published in one of the repositories defined in the channel.
+When blocklists are published as Maven artifacts, they must use the classifier `blocklist` and extension/type `yaml`.
 
 #### Update a channel
 
@@ -137,9 +145,9 @@ They consume channels by pulling the channel artifact corresponding to the `grou
 
 #### Resolving channel manifest
 
-The manifest is resolved when a channel is initialized. The channel can omit the manifest definition in which case the `resolve-if-no-stream` strategy will be used to find artifacts.
+The manifest is resolved when a channel is initialized. The channel can omit the manifest definition in which case the `resolve-if-no-stream` strategy will be used to resolve artifacts.
 
-If the channel defines a manifest using URL, the manifest will be read from that location. If instead GAV is used the specified version of manifest is resolved from channel's repositories. If only `groupId` and `artifactId` is provided, the latest available version of the channel manifest will be used.
+If the channel defines a manifest using URL, the manifest will be read from that location. If instead maven coordinates are used, the specified version of manifest is resolved from the channel's repositories. If only `groupId` and `artifactId` is provided, the latest available version of the channel manifest (as defined in <<Component Version>>) will be used.
 
 If the chanel defines a manifest, but no manifest can be resolved (using either URL or GA[V]), an error will be thrown.
 
@@ -156,8 +164,9 @@ If channel does not directly define a stream, required channels will be searched
 
 If multiple channels are defined, the latest version from any channel that defines the stream (directly or through required channels) is used.
 
-If no stream that matches the artifact have been found, version is resolved using fallback strategy defined in `resolves-if-no-stream` for the channel.
+If no stream that matches the artifact have been found, version is resolved using fallback strategy defined in `resolve-if-no-stream` for the channel.
 An error is returned to the caller if
+
 * the fallback strategy is `none`
 * the fallback strategy is `latest`, `maven-latest` or `maven-release` but underlying Maven repository contains no metadata for artifacts with required `groupId` and `artifactId`
 
@@ -172,29 +181,38 @@ A channel defines repositories using their `id` and a default `url`. When creati
 
 ### Blocking artifact versions
 When using an open channel, a situation may arise where certain artifacts are promoted to the channel and later discovered to be invalid. As it’s impossible to remove artifacts already deployed into a repository, those versions have to blocklisted.
-The blocklist is a separate YAML artifact included in the channel itself. When channel resolves the blacklist artifact, it will always resolve the latest available version. Any changes to the blocked artifact versions can be done independently of channel changes.
+
 #### Format
-The blocklist file contains a list of stream GAVs with multiple versions:
+The blocklist file contains a list of stream Maven coordinates with multiple versions:
 ```
 ---
-exclusions:
+blocks:
 - groupId: io.undertow
-artifactId: undertow-core
-versions: [2.2.18.Final, 2.2.17.Final]
+  artifactId: undertow-core
+  versions:
+  - 2.2.18.Final
+  - 2.2.17.Final
 …
 ```
 The artifactId can use a wildcard syntax to refer to all the artifacts with the same groupId
 ```
 ---
-exclusions:
+blocks:
 - groupId: io.undertow
-artifactId: “*”
-versions: [2.2.18.Final, 2.2.17.Final]
+  artifactId: “*”
+  versions:
+  - 2.2.18.Final
+  - 2.2.17.Final
 ```
 
 #### Resolving channel blocklist
 
-The blocklist is resolved when a channel is initialized. If no blocklist artifact can be resolved with supplied GAVs, the channel treats it as an empty blocklist.
+The blocklist is resolved when a channel is initialized.
+
+If the channel defines a blocklist using URL, the blocklist will be read from that location. If instead maven coordinates are used, the specified version of manifest is resolved from the channel's repositories. If only `groupId` and `artifactId` is provided, the latest available version of the blocklist (as defined in <<Component Version>>) will be used.
+
+If no blocklist artifact can be resolved with supplied Maven coordinates, the channel treats it as an empty blocklist.
+
 A blocklist applies only to the channel that defined it, not its required channels.
 
 #### Resolving artifact version
@@ -208,7 +226,7 @@ The blocklist is ignored when using `resolveDirectMavenArtifact` method.
 
 ### Version 2.0.0
 
-* Introduction of the Channel Manifest
+* Introduction of the Channel Manifest and Blocklist
 
 ### Version 1.0.0
 

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -5,7 +5,9 @@
 
 [cols="1,1"]
 |===
-| Schema Version | 1.0.0 |
+| Channel schema Version | 2.0.0
+| Manifest schema Version | 1.0.0
+| Blocklist schema Version | 1.0.0
 |===
 
 ### Summary
@@ -40,6 +42,8 @@ Backwards compatibility is only guaranteed inside a single channel. If an instal
 
 ## Channel Model
 
+Channel combines a Channel Manifest defining content of channel, one or more Repositories from which the content can be resolved and an optional Blocklist Manifest.
+
 A channel is composed of several fields:
 
 * An optional `name` that is a human-readable one-line description of the channel (`Channel for WildFly 27`)
@@ -55,6 +59,28 @@ This field can be used for layered products to enforce their dependencies so tha
 Each element is composed of:
 ** Mandatory `groupId` and `artifactId` elements that are the Maven coordinates of the required channel.
 ** Optional `version` to stick to a given channel version (instead of requiring the latest version of that channel). In the absence of this `version`, the latest version of the channel will be determined based on the Maven repository metadata.
+* A collection of `repositories` that defines repositories associated with the channel. Only listed repositories are used to resolve channel's components. Each repository is composed of:
+** A required `id` that defines the repository name used in Maven cache
+** A required `url` pointing to a default Maven repository
+* Optional `manifest` corresponding to the Channel Manifest artefact. Channel Manifest is used to define streams available in the channel.
+** One of the following, mutually exclusive fields, used to resolve the Channel Manifest:
+*** `gav` corresponds to Maven coordinates of the Manifest. It can either use format of `groupId:artifactId` (resulting in the latest available version being used) or `groupId:artifactId:version` (resulting in concrete version being used)
+*** `url` corresponding to a static URL where the manifest file can be found.
+* Optional `blocklist` corresponding to the Blocklist artefact. Blocklist is used to define versions of artifacts excluded from a channel.
+** One of the following, mutually exclusive fields, used to resolve the Blocklist:
+*** `gav` corresponds to Maven coordinates of the Manifest. It can either use format of `groupId:artifactId` (resulting in the latest available version being used) or `groupId:artifactId:version` (resulting in concrete version being used)
+*** `url` corresponding to a static URL where the manifest file can be found.
+* An optional `resolves-if-no-stream` that defines strategy for version resolution if the artifact has not been found in the `streams` collection. Allowed values are:
+** `original` - fallback to the `baseVersion` provided when querying the channel. Default value if no strategy is provided.
+** `latest` - use the latest version found in the Maven repositories
+** `maven-latest` - a version marked as `latest` in the Maven metadata
+** `maven-release` - a version marked as `release` in the Maven metadata
+** `none` - do not attempt to resolve versions of artifact not listed in the `streams` collection
+
+A Channel Manifest is composed of following fields:
+
+* An optional `name` that is a human-readable one-line description of the channel (`Channel for WildFly 27`)
+* An optional `description` that provides human-readable description of the channel
 * A collection of `streams` that defines all the components installable from this channel. Each stream is composed of:
 ** A required `groupId` that corresponds to Maven GroupId to pull artifacts (it is not allowed to specify `*` for the groupId).
 ** A required `artifactId` that corresponds to Maven ArtifactId to pull artifacts. Special syntax `*` can be used to match _any_ artifactId.
@@ -69,37 +95,58 @@ A channel does not provide any default streams.
 
 ## Channel Schema
 
-A JSON Schema is provided to validate that channels comply with the model described above.
+JSON Schemas are provided to validate that channels and manifests comply with the model described above.
 
 ## Channel Representation
 
-A channel is specified in the YAML language with a link:../core/src/main/resources/org/wildfly/channel/v1.0.0./schema.json[corresponding JSON schema] to validate its structure.
+A channel is specified in the YAML language with a link:../core/src/main/resources/org/wildfly/channel/v2.0.0./schema.json[corresponding JSON schema] to validate its structure.
+
+A manifest is specified in the YAML language with a link:../core/src/main/resources/org/wildfly/manifest/v1.0.0./schema.json[corresponding JSON schema] to validate its structure.
+
+A blocklist is specified in the YAML language with a link:.
+./core/src/main/resources/org/wildfly/blocklist/v1.0.0./schema.json[corresponding JSON schema] to validate its structure.
 
 ### Channel Actions and Responsibilities
 
 #### Create a channel
 
-A Channel is a single file that complies with the channel YAML representation.
-Creating a channel corresponds to the creation of such a file.
+A minimal Channel definition is a single file that complies with the channel YAML representation. The Channel definition may reference two additional resources: a Manifest file and a Blocklist file.
+
+Creating a channel corresponds to the creation of the above files.
 
 #### Publish a channel
-A channel must be “published” so that it can be read (or downloaded) by WildFly provisioning tooling. 
-Channels are published as a Maven artifact with the the classifier `channel` and extension/type `yaml`.
+A channel may be “published” so that it can be read (or downloaded) by WildFly provisioning tooling.
+Channels are published as a Maven artifact with the classifier `channel` and extension/type `yaml`.
+
+Manifest and Blocklist files must be "published" in one of the repositories defined in the Channel so that the Channel is able to resolve them.
+
+Manifests are published as Maven artifacts with the classifier `manifest` and extension/type `yaml`.
+
+Blocklists are published as Maven artifacts with the classifier `blocklist` and extension/type `yaml`. The manifest needs to be published in one of the repositories defined in the channel.
 
 #### Update a channel
 
-A channel definition can be updated to add or modify streams, change its requirements, etc.
-A new version of the channel must be published before it can be consumed.
+A channel definition and manifest can be updated to add or modify streams, change its requirements, etc. Each of the channel files can be updated independently of each other.
+
+To update a channel file, it needs to be published with a new version.
 
 #### Consume a channel
 The main consumers of WildFly Channels are the provisioning tooling provided by the WildFly project.
 
 They consume channels by pulling the channel artifact corresponding to the `groupId`/`artifactId` of a channel. If a `version` is specified, the channel corresponding to that version is pulled. Otherwise, the latest version of the channel is determined based on the Maven metadata from the repository that hosts the channel artifacts.
 
+#### Resolving channel manifest
+
+The manifest is resolved when a channel is initialized. The channel can omit the manifest definition in which case the `resolve-if-no-stream` strategy will be used to find artifacts.
+
+If the channel defines a manifest using URL, the manifest will be read from that location. If instead GAV is used the specified version of manifest is resolved from channel's repositories. If only `groupId` and `artifactId` is provided, the latest available version of the channel manifest will be used.
+
+If the chanel defines a manifest, but no manifest can be resolved (using either URL or GA[V]), an error will be thrown.
+
 ### Maven Artifact resolution
 
 A Maven artifact can be resolved through a channel.
-Such a resolution will use the Maven repositories configured by the provisioning tool.
+Such a resolution will use the Maven repositories defined within the channel. If a channel `requires` a different channel, the required channel will use the repositories from its own definition.
 
 The channels will be searched for a stream that matches the `groupId`/`artifactId` of the artifact.
 
@@ -109,14 +156,59 @@ If channel does not directly define a stream, required channels will be searched
 
 If multiple channels are defined, the latest version from any channel that defines the stream (directly or through required channels) is used.
 
-If no stream that matches the artifact have been found, an error is returned to the caller.
+If no stream that matches the artifact have been found, version is resolved using fallback strategy defined in `resolves-if-no-stream` for the channel.
+An error is returned to the caller if
+* the fallback strategy is `none`
+* the fallback strategy is `latest`, `maven-latest` or `maven-release` but underlying Maven repository contains no metadata for artifacts with required `groupId` and `artifactId`
 
 If the stream defines a `version`, the artifact will be resolved based on this version. If that version of the artifact can not be pulled
 from the Maven repositories, an error is returned to the caller.
 If the stream defines a `versionPattern`, the version will be determined by querying the version of the artifacts from the
 Maven repositories and use the latest version that matches the pattern. If no version matches the pattern, an error is returned to the caller.
 
+#### Maven repository proxies
+
+A channel defines repositories using their `id` and a default `url`. When creating the channel from definition the provisioning tool can replace the provided `url` with URL of a proxy server or an alternative repository. The `id` of the repository must not be changed.
+
+### Blocking artifact versions
+When using an open channel, a situation may arise where certain artifacts are promoted to the channel and later discovered to be invalid. As it’s impossible to remove artifacts already deployed into a repository, those versions have to blocklisted.
+The blocklist is a separate YAML artifact included in the channel itself. When channel resolves the blacklist artifact, it will always resolve the latest available version. Any changes to the blocked artifact versions can be done independently of channel changes.
+#### Format
+The blocklist file contains a list of stream GAVs with multiple versions:
+```
+---
+exclusions:
+- groupId: io.undertow
+artifactId: undertow-core
+versions: [2.2.18.Final, 2.2.17.Final]
+…
+```
+The artifactId can use a wildcard syntax to refer to all the artifacts with the same groupId
+```
+---
+exclusions:
+- groupId: io.undertow
+artifactId: “*”
+versions: [2.2.18.Final, 2.2.17.Final]
+```
+
+#### Resolving channel blocklist
+
+The blocklist is resolved when a channel is initialized. If no blocklist artifact can be resolved with supplied GAVs, the channel treats it as an empty blocklist.
+A blocklist applies only to the channel that defined it, not its required channels.
+
+#### Resolving artifact version
+
+During artifact version resolution, a stream matching artifact GA is located in the channel. If the stream uses concrete versions, that version of the artifact is resolved and returned to the user.
+If the stream uses `versionPattern`, the blocklist is checked for excluded versions. The excluded versions are removed from the set of available artifact versions before the latest remaining version matching the stream’s pattern is used to resolve the artifact.
+If the blocklist excludes all available artifact versions, `UnresolvedMavenArtifactException` is thrown.
+The blocklist is ignored when using `resolveDirectMavenArtifact` method.
+
 ### Changelog
+
+### Version 2.0.0
+
+* Introduction of the Channel Manifest
 
 ### Version 1.0.0
 

--- a/maven-resolver/src/main/java/org/wildfly/channel/maven/ChannelCoordinate.java
+++ b/maven-resolver/src/main/java/org/wildfly/channel/maven/ChannelCoordinate.java
@@ -16,73 +16,32 @@
  */
 package org.wildfly.channel.maven;
 
-import static java.util.Objects.requireNonNull;
+import org.wildfly.channel.Channel;
+import org.wildfly.channel.ChannelMetadataCoordinate;
 
 import java.net.URL;
-import java.util.Objects;
 
 /**
  * A channel coordinate either use Maven coordinates (groupId, artifactId, version)
  * or it uses a URL from which the channel definition file can be fetched.
  */
-public class ChannelCoordinate {
-    private String groupId;
-    private String artifactId;
-    private String version;
-    // raw Channel file from an URL
-    private URL url;
+public class ChannelCoordinate extends ChannelMetadataCoordinate {
 
     // empty constructor used by the wildlfy-maven-plugin
     // through reflection
     public ChannelCoordinate() {
+        super();
     }
 
     public ChannelCoordinate(String groupId, String artifactId, String version) {
-        this(groupId, artifactId, version, null);
-        requireNonNull(groupId);
-        requireNonNull(artifactId);
-        requireNonNull(version);
+        super(groupId, artifactId, version, Channel.CLASSIFIER, Channel.EXTENSION);
     }
 
     public ChannelCoordinate(String groupId, String artifactId) {
-        this(groupId, artifactId, null, null);
-        requireNonNull(groupId);
-        requireNonNull(artifactId);
+        super(groupId, artifactId, Channel.CLASSIFIER, Channel.EXTENSION);
     }
 
     public ChannelCoordinate(URL url) {
-        this(null, null, null, url);
-        requireNonNull(url);
-    }
-
-    private ChannelCoordinate(String groupId, String artifactId, String version, URL url) {
-        this.groupId = groupId;
-        this.artifactId = artifactId;
-        this.version = version;
-        this.url = url;
-    }
-
-    public URL getUrl() {
-        return url;
-    }
-
-    public String getGroupId() {
-        return groupId;
-    }
-
-    public String getArtifactId() {
-        return artifactId;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getExtension() {
-        return "yaml";
-    }
-
-    public String getClassifier() {
-        return "channel";
+        super(url);
     }
 }

--- a/maven-resolver/src/test/java/org/wildfly/channel/maven/VersionResolverFactoryTest.java
+++ b/maven-resolver/src/test/java/org/wildfly/channel/maven/VersionResolverFactoryTest.java
@@ -25,23 +25,32 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.metadata.DefaultMetadata;
+import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.MetadataRequest;
+import org.eclipse.aether.resolution.MetadataResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
@@ -248,14 +257,14 @@ public class VersionResolverFactoryTest {
         RepositorySystemSession session = mock(RepositorySystemSession.class);
 
         VersionResolverFactory factory = new VersionResolverFactory(system, session,
-                r->new RemoteRepository.Builder(r.getId(), "default", r.getUrl() + ".new").build());
+                r -> new RemoteRepository.Builder(r.getId(), "default", r.getUrl() + ".new").build());
         MavenVersionsResolver resolver = factory.create(List.of(new Repository("test_1", "http://test_1")));
 
         File artifactFile = new File("test");
         ArtifactResult artifactResult = new ArtifactResult(new ArtifactRequest());
         Artifact artifact = mock(Artifact.class);
         artifactResult.setArtifact(artifact);
-        when (artifact.getFile()).thenReturn(artifactFile);
+        when(artifact.getFile()).thenReturn(artifactFile);
 
         ArgumentCaptor<ArtifactRequest> captor = ArgumentCaptor.forClass(ArtifactRequest.class);
 
@@ -266,6 +275,99 @@ public class VersionResolverFactoryTest {
         final List<RemoteRepository> actualRepos = captor.getAllValues().get(0).getRepositories();
         assertEquals(1, actualRepos.size());
         assertEquals("http://test_1.new", actualRepos.get(0).getUrl());
+    }
+
+    public void testResolveReleaseFromMetadata() throws Exception {
+        RepositorySystem system = mock(RepositorySystem.class);
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
+
+        final MetadataResult result1 = getMetadataResult("1.0.0.Final", "1.0.1.Final-SNAPSHOT");
+        final MetadataResult result2 = getMetadataResult("1.0.1.Final", "1.0.1.Final-SNAPSHOT");
+        when(system.resolveMetadata(eq(session), any())).thenReturn(List.of(result1, result2));
+
+        VersionResolverFactory factory = new VersionResolverFactory(system, session);
+        MavenVersionsResolver resolver = factory.create(any());
+
+        final String res = resolver.getMetadataReleaseVersion("org.foo", "bar");
+
+        assertEquals("1.0.1.Final", res);
+    }
+
+    @Test
+    public void testResolveLatestFromMetadata() throws Exception {
+        RepositorySystem system = mock(RepositorySystem.class);
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
+
+        final MetadataResult result1 = getMetadataResult("1.0.0.Final", "1.0.0.Final");
+        final MetadataResult result2 = getMetadataResult("1.0.0.Final", "1.0.1.Final");
+        when(system.resolveMetadata(eq(session), any())).thenReturn(List.of(result1, result2));
+
+        VersionResolverFactory factory = new VersionResolverFactory(system, session);
+        MavenVersionsResolver resolver = factory.create(Collections.emptyList());
+
+        final String res = resolver.getMetadataLatestVersion("org.foo", "bar");
+
+        assertEquals("1.0.1.Final", res);
+    }
+
+    @Test
+    public void testResolveLatestFromMetadataNoVersioning() throws Exception {
+        RepositorySystem system = mock(RepositorySystem.class);
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
+
+        final org.apache.maven.artifact.repository.metadata.Metadata resMetadata = new org.apache.maven.artifact.repository.metadata.Metadata();
+        resMetadata.setGroupId("org.foo");
+        resMetadata.setArtifactId("bar");
+
+        final MetadataResult result = wrapMetadata(resMetadata);
+        when(system.resolveMetadata(eq(session), any())).thenReturn(List.of(result));
+
+        VersionResolverFactory factory = new VersionResolverFactory(system, session);
+        MavenVersionsResolver resolver = factory.create(Collections.emptyList());
+
+        Assertions.assertThrows(UnresolvedMavenArtifactException.class, () -> {
+            resolver.getMetadataLatestVersion("org.foo", "bar");
+        });
+    }
+
+    @Test
+    public void testResolveLatestFromMetadataNoLatestVersion() throws Exception {
+        RepositorySystem system = mock(RepositorySystem.class);
+        RepositorySystemSession session = mock(RepositorySystemSession.class);
+
+        final MetadataResult result = getMetadataResult("1.0.0.Final", null);
+        when(system.resolveMetadata(eq(session), any())).thenReturn(List.of(result));
+
+        VersionResolverFactory factory = new VersionResolverFactory(system, session);
+        MavenVersionsResolver resolver = factory.create(Collections.emptyList());
+
+        Assertions.assertThrows(UnresolvedMavenArtifactException.class, () -> {
+            resolver.getMetadataLatestVersion("org.foo", "bar");
+        });
+    }
+
+    private MetadataResult getMetadataResult(String releaseVersion, String latestVersion) throws IOException {
+        final org.apache.maven.artifact.repository.metadata.Metadata resMetadata = new org.apache.maven.artifact.repository.metadata.Metadata();
+        resMetadata.setGroupId("org.foo");
+        resMetadata.setArtifactId("bar");
+        final Versioning versioning = new Versioning();
+        versioning.setRelease(releaseVersion);
+        versioning.setLatest(latestVersion);
+        versioning.setVersions(List.of("1.0.1.Final-SNAPSHOT", releaseVersion));
+        resMetadata.setVersioning(versioning);
+
+        return wrapMetadata(resMetadata);
+    }
+
+    private MetadataResult wrapMetadata(org.apache.maven.artifact.repository.metadata.Metadata resMetadata) throws IOException {
+        final Path tempFile = Files.createTempFile("test", "xml");
+        tempFile.toFile().deleteOnExit();
+        new MetadataXpp3Writer().write(new FileWriter(tempFile.toFile()), resMetadata);
+        final MetadataResult result = new MetadataResult(new MetadataRequest());
+        final Metadata metadata = new DefaultMetadata("org.foo", "bar", "maven-metadata.xml", Metadata.Nature.RELEASE)
+           .setFile(tempFile.toFile());
+        result.setMetadata(metadata);
+        return result;
     }
 }
 


### PR DESCRIPTION
Implementation of #97 using `resolves-if-no-stream` instead of wildcard `groupId`s. 

Alternative for #98 

@jmesnil sorry for delay, this is an implementation based on your comment in https://github.com/wildfly-extras/wildfly-channel/issues/97#issuecomment-1217692188
I implemented `latest` strategy using `VersionMatcher.COMPARATOR` instead of Maven metadata to keep it consistent with `versionPattern` behaviour.