### PR TITLE
[#95] Channel Blocklist

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -255,7 +256,9 @@ public class Channel implements AutoCloseable {
             foundVersion = Optional.of(stream.getVersion());
         } else if (stream.getVersionPattern() != null) {
             // if there is a version pattern, we resolve all versions from Maven to find the latest one
-            Set<String> versions = resolver.getAllVersions(groupId, artifactId, extension, classifier);
+            Set<String> versions = new HashSet<>(resolver.getAllVersions(groupId, artifactId, extension, classifier));
+            versions.removeAll(stream.getExcludedVersions());
+
             foundVersion = foundStream.get().getVersionComparator().matches(versions);
         }
 

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -54,9 +54,11 @@ import com.networknt.schema.ValidationMessage;
 public class ChannelMapper {
 
     public static final String SCHEMA_VERSION_1_0_0 = "1.0.0";
-    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_0;
+    public static final String SCHEMA_VERSION_1_0_1 = "1.0.1";
+    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_1;
 
     private static final String SCHEMA_1_0_0_FILE = "org/wildfly/channel/v1.0.0/schema.json";
+    private static final String SCHEMA_1_0_1_FILE = "org/wildfly/channel/v1.0.1/schema.json";
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory()
             .configure(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
@@ -67,6 +69,7 @@ public class ChannelMapper {
 
     static {
         SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
+        SCHEMAS.put(SCHEMA_VERSION_1_0_1, SCHEMA_FACTORY.getSchema(ChannelMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_1_FILE)));
     }
 
     private static JsonSchema getSchema(JsonNode node) {

--- a/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelRecorder.java
@@ -17,13 +17,14 @@
 package org.wildfly.channel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 
 class ChannelRecorder {
     private ConcurrentHashMap<String, Stream> streams = new ConcurrentHashMap<>();
 
     void recordStream(String groupId, String artifactId, String version) {
-        streams.putIfAbsent(groupId + ":" + artifactId + ":" + version, new Stream(groupId, artifactId, version, null));
+        streams.putIfAbsent(groupId + ":" + artifactId + ":" + version, new Stream(groupId, artifactId, version, null, Collections.emptySet()));
     }
 
     Channel getRecordedChannel() {

--- a/core/src/main/resources/org/wildfly/channel/v1.0.1/schema.json
+++ b/core/src/main/resources/org/wildfly/channel/v1.0.1/schema.json
@@ -1,0 +1,111 @@
+{
+  "$id": "https://wildfly.org/channels/v1.0.1/schema.json",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a channel resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "name": {
+      "description": "Name of the channel. This is a one-line human-readable description of the channel",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the channel. This is a multi-lines human-readable description of the channel",
+      "type": "string"
+    },
+    "vendor": {
+      "description": "Vendor of the channel.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the vendor",
+          "type": "string"
+        },
+        "support": {
+          "description": "Support level provided by the vendor",
+          "type": "string",
+          "enum": [
+            "supported",
+            "tech-preview",
+            "community"
+          ]
+        }
+      },
+      "required": ["name", "support"]
+    },
+    "requires": {
+      "description": "Channels that are required by this channel.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minItems": 1,
+        "properties": {
+          "groupId": {
+            "description": "GroupID Maven coordinate of the channel",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactID Maven coordinate of the channel",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version Maven coordinate of the channel",
+            "type": "string"
+          }
+        },
+        "required": ["groupId", "artifactId"]
+      }
+    },
+    "streams":{
+      "description": "Streams of components that are provided by this channel",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "description": "GroupId of the stream. It must be a valid groupId (corresponding to a G of a Maven GAV)",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactId of the stream. It must be either a valid artifactId (corresponding to a A of a Maven GAV) or the * character to represent any artifactId",
+            "type": "string"
+          },
+          "version" : {
+            "description": "Version of the stream. This must be either a single version. Only one of version, versionPattern must be set.",
+            "type": "string"
+          },
+          "versionPattern" : {
+            "description": "VersionPattern of the stream. This is a regular expression that matches any version from this stream. Only one of version, versionPattern must be set.",
+            "type": "string"
+          },
+          "excludedVersions" : {
+            "description": "",
+            "type" : "array",
+            "minItems" : 1,
+            "items" : {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["groupId", "artifactId"],
+        "oneOf": [
+          {
+            "required": ["version"]
+          },
+          {
+            "required": ["versionPattern"]
+          }
+        ],
+        "not":
+        {
+          "required": ["version", "excludedVersions"]
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/wildfly/channel/ChannelWithVersionExclusionsTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelWithVersionExclusionsTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.channel;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.channel.spi.MavenVersionsResolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.wildfly.channel.ChannelMapper.CURRENT_SCHEMA_VERSION;
+
+public class ChannelWithVersionExclusionsTestCase {
+
+    @Test
+    public void testFindLatestMavenArtifactVersion() throws Exception {
+        List<Channel> channels = ChannelMapper.fromString(
+                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
+                "  - groupId: org.wildfly\n" +
+                "    artifactId: '*'\n" +
+                "    versionPattern: '25\\.\\d+\\.\\d+.Final'\n" +
+                "    excludedVersions:\n" +
+                "      - '25.0.1.Final'");
+        assertNotNull(channels);
+        assertEquals(1, channels.size());
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+
+        when(factory.create()).thenReturn(resolver);
+        when(resolver.getAllVersions("org.wildfly", "wildfly-ee-galleon-pack", null, null))
+           .thenReturn(new HashSet<>(Arrays.asList("25.0.0.Final", "25.0.1.Final")));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            String version = session.findLatestMavenArtifactVersion("org.wildfly", "wildfly-ee-galleon-pack", null, null, "25.0.0.Final");
+            assertEquals("25.0.0.Final", version);
+        }
+
+        verify(resolver, times(2)).close();
+    }
+
+    @Test
+    public void testFindLatestMavenArtifactVersionExcludesAllVersionsException() throws Exception {
+        List<Channel> channels = ChannelMapper.fromString(                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
+                "  - groupId: org.wildfly\n" +
+                "    artifactId: '*'\n" +
+                "    versionPattern: '25\\.\\d+\\.\\d+.Final'\n" +
+                "    excludedVersions:\n" +
+                "      - '25.0.1.Final'\n" +
+                "      - '25.0.0.Final'");
+        assertNotNull(channels);
+        assertEquals(1, channels.size());
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+
+        when(factory.create()).thenReturn(resolver);
+        when(resolver.getAllVersions("org.wildfly", "wildfly-ee-galleon-pack", null, null)).thenReturn(new HashSet<>(Set.of("25.0.0.Final", "25.0.1.Final")));
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+            try {
+                session.findLatestMavenArtifactVersion("org.wildfly", "wildfly-ee-galleon-pack", null, null, "26.0.0.Final");
+                fail("Must throw a UnresolvedMavenArtifactException");
+            } catch (UnresolvedMavenArtifactException e) {
+                // pass
+            }
+        }
+
+        verify(resolver, times(2)).close();
+    }
+
+    @Test
+    public void testResolveLatestMavenArtifact() throws Exception {
+        List<Channel> channels = ChannelMapper.fromString("schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                "streams:\n" +
+                "  - groupId: org.wildfly\n" +
+                "    artifactId: '*'\n" +
+                "    versionPattern: '25\\.\\d+\\.\\d+.Final'\n" +
+                "    excludedVersions:\n" +
+                "      - '25.0.1.Final'");
+        assertNotNull(channels);
+        assertEquals(1, channels.size());
+
+        MavenVersionsResolver.Factory factory = mock(MavenVersionsResolver.Factory.class);
+        MavenVersionsResolver resolver = mock(MavenVersionsResolver.class);
+        File resolvedArtifactFile = mock(File.class);
+
+        when(factory.create()).thenReturn(resolver);
+        when(resolver.getAllVersions("org.wildfly", "wildfly-ee-galleon-pack", null, null)).thenReturn(new HashSet<>(Set.of("25.0.0.Final", "25.0.1.Final", "25.0.2.Final")));
+        when(resolver.resolveArtifact("org.wildfly", "wildfly-ee-galleon-pack", null, null, "25.0.2.Final")).thenReturn(resolvedArtifactFile);
+
+        try (ChannelSession session = new ChannelSession(channels, factory)) {
+
+            MavenArtifact artifact = session.resolveMavenArtifact("org.wildfly", "wildfly-ee-galleon-pack", null, null, "25.0.0.Final");
+            assertNotNull(artifact);
+
+            assertEquals("org.wildfly", artifact.getGroupId());
+            assertEquals("wildfly-ee-galleon-pack", artifact.getArtifactId());
+            assertNull(artifact.getExtension());
+            assertNull(artifact.getClassifier());
+            assertEquals("25.0.2.Final", artifact.getVersion());
+            assertEquals(resolvedArtifactFile, artifact.getFile());
+        }
+
+        verify(resolver, times(2)).close();
+    }
+
+    @Test
+    public void testChannelWithVersionAndExclusion() throws Exception {
+        Assertions.assertThrows(InvalidChannelException.class, ()->
+            ChannelMapper.fromString(
+                "schemaVersion: " + CURRENT_SCHEMA_VERSION + "\n" +
+                        "streams:\n" +
+                        "  - groupId: org.wildfly\n" +
+                        "    artifactId: '*'\n" +
+                        "    version: '25.0.0.Final'\n" +
+                        "    excludedVersions:\n" +
+                        "      - '25.0.1.Final'")
+        );
+
+    }
+}

--- a/core/src/test/java/org/wildfly/channel/mapping/StreamTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/mapping/StreamTestCase.java
@@ -109,12 +109,22 @@ public class StreamTestCase {
     }
 
     @Test
-    public void tesVersionAndVersionPatternAreBothDefined()  {
+    public void testVersionAndVersionPatternAreBothDefined()  {
         assertThrows(Exception.class, () -> {
             Stream stream = fromYamlContent("groupId: org.wildfly\n" +
                     "artifactId: wildfly-ee-galleon-pack\n" +
                     "version: 26.0.0.Final\n" +
                     "versionPattern: \"2\\\\.2\\\\..*\"");
+        });
+    }
+
+    @Test
+    public void testVersionAndExcludedVersionsAreBothDefined() throws Exception {
+        assertThrows(Exception.class, () -> {
+            Stream stream = fromYamlContent("groupId: org.wildfly\n" +
+                    "artifactId: wildfly-ee-galleon-pack\n" +
+                    "version: 26.0.0.Final\n" +
+                    "excludedVersions: [ 26.0.0.Final ]");
         });
     }
 }

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -5,7 +5,7 @@
 
 [cols="1,1"]
 |===
-| Schema Version | 1.0.0 |
+| Schema Version | 1.0.1 |
 |===
 
 ### Summary
@@ -61,6 +61,7 @@ Each element is composed of:
 ** One of the following fields (which are mutually exclusive) that provides rules to resolve the Maven artifacts to provision. At most one field must be present in the stream definition.
 *** `versionPattern` corresponds to a Pattern through which the available versions are matched (e.g. `2\.2\..*`)
 *** `version` corresponds to a single version (e.g. `2.2.Final`)
+** An optional `excludedVersions` lists versions to be excluded from a stream (e.g. `[ 2.2.2.Final ]`). This field can only be used together with `versionPattern`.
 
 A channel does not define the Maven repositories that contain the resolved Maven artifacts from any of its streams.
 It is up to the provisioning tooling to properly configure the required Maven repositories.
@@ -114,11 +115,14 @@ If no stream that matches the artifact have been found, an error is returned to 
 If the stream defines a `version`, the artifact will be resolved based on this version. If that version of the artifact can not be pulled
 from the Maven repositories, an error is returned to the caller.
 If the stream defines a `versionPattern`, the version will be determined by querying the version of the artifacts from the
-Maven repositories and use the latest version that matches the pattern. If no version matches the pattern, an error is returned to the caller.
+Maven repositories. Any versions listed in `excludedVersions` will be ignored and the latest remaining version that matches the pattern will be resolved. If no version matches the pattern, or all eligible versions are excluded, an error is returned to the caller.
 
 ### Changelog
 
 ### Version 1.0.0
 
 * Initial release of the Channel specification
+
+### Version 1.0.1
+* Added `excludedVersions` to the stream definition
 


### PR DESCRIPTION
Fixes #95.

Alternative implementation to #96 - using `excludedVersions` in the the channel YAML.

cc. @wolfc