### PR TITLE
Serialize manifest coordinate as 'manifest'

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -121,6 +121,7 @@ public class Channel {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("manifest")
     public ChannelManifestCoordinate getManifestCoordinate() {
         return manifestCoordinate;
     }

--- a/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelMapperTestCase.java
@@ -17,7 +17,9 @@
 package org.wildfly.channel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
 import java.util.List;
@@ -38,6 +40,7 @@ public class ChannelMapperTestCase {
 
         final Channel channel1 = ChannelMapper.fromString(yaml).get(0);
         assertEquals(Vendor.Support.COMMUNITY, channel1.getVendor().getSupport());
+        assertFalse(yaml.contains("manifestCoordinate:"));
     }
 
     @Test


### PR DESCRIPTION
Channel serialization produces 
```
  manifestCoordinate:
    maven:
      ..
```

the spec dictates:
```
  manifest:
    maven:
      ..
```