### PR TITLE
Exclude locally installed artifacts from version resolution

### DIFF
--- a/maven-resolver/src/main/java/org/wildfly/channel/maven/VersionResolverFactory.java
+++ b/maven-resolver/src/main/java/org/wildfly/channel/maven/VersionResolverFactory.java
@@ -43,6 +43,7 @@ import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.metadata.DefaultMetadata;
 import org.eclipse.aether.metadata.Metadata;
+import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -135,7 +136,9 @@ public class VersionResolverFactory implements MavenVersionsResolver.Factory {
 
             try {
                 VersionRangeResult versionRangeResult = system.resolveVersionRange(session, versionRangeRequest);
-                Set<String> versions = versionRangeResult.getVersions().stream().map(Version::toString).collect(Collectors.toSet());
+                Set<String> versions = versionRangeResult.getVersions().stream()
+                        .filter(v->!(versionRangeResult.getRepository(v) instanceof LocalRepository))
+                        .map(Version::toString).collect(Collectors.toSet());
                 return versions;
             } catch (VersionRangeResolutionException e) {
                 return emptySet();


### PR DESCRIPTION
When resolving artifact versions, only repositories defined in the channel should be used.

By default Maven adds additional request to local cache repositore (e.g. ~/.m2/repository).

This doesn't prevent using cached metadata in offline mode.
