### PR TITLE
Throw InvalidChannelMetadataException when metadata doesn't declare valid schema version

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Blocklist.java
+++ b/core/src/main/java/org/wildfly/channel/Blocklist.java
@@ -130,11 +130,11 @@ public class Blocklist {
       JsonNode schemaVersion = node.path("schemaVersion");
       String version = schemaVersion.asText();
       if (version == null || version.isEmpty()) {
-         throw new RuntimeException("The blocklist does not specify a schemaVersion.");
+         throw new InvalidChannelMetadataException("Invalid Manifest", List.of("The manifest does not specify a schemaVersion."));
       }
       JsonSchema schema = SCHEMAS.get(version);
       if (schema == null) {
-         throw new RuntimeException("Unknown schema version " + schemaVersion);
+         throw new InvalidChannelMetadataException("Invalid Manifest", List.of("Unknown schema version " + schemaVersion));
       }
       return schema;
    }

--- a/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
@@ -70,11 +70,11 @@ public class ChannelManifestMapper {
         JsonNode schemaVersion = node.path("schemaVersion");
         String version = schemaVersion.asText();
         if (version == null || version.isEmpty()) {
-            throw new RuntimeException("The manifest does not specify a schemaVersion.");
+            throw new InvalidChannelMetadataException("Invalid Manifest", List.of("The manifest does not specify a schemaVersion."));
         }
         JsonSchema schema = SCHEMAS.get(version);
         if (schema == null) {
-            throw new RuntimeException("Unknown schema version " + schemaVersion);
+            throw new InvalidChannelMetadataException("Invalid Manifest", List.of("Unknown schema version " + schemaVersion));
         }
         return schema;
     }

--- a/core/src/main/java/org/wildfly/channel/ChannelMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelMapper.java
@@ -73,11 +73,11 @@ public class ChannelMapper {
         JsonNode schemaVersion = node.path("schemaVersion");
         String version = schemaVersion.asText();
         if (version == null || version.isEmpty()) {
-            throw new RuntimeException("The channel does not specify a schemaVersion.");
+            throw new InvalidChannelMetadataException("Invalid Manifest", List.of("The manifest does not specify a schemaVersion."));
         }
         JsonSchema schema = SCHEMAS.get(version);
         if (schema == null) {
-            throw new RuntimeException("Unknown schema version " + schemaVersion);
+            throw new InvalidChannelMetadataException("Invalid Manifest", List.of("Unknown schema version " + schemaVersion));
         }
         return schema;
     }


### PR DESCRIPTION
Throw InvalidChannelMetadataException instead of generic RuntimeException to make it easier to catch and report correctly in clients.
