### PR TITLE
Introduce two exceptions to distinquish between resolution failures

### DIFF
--- a/core/src/main/java/org/wildfly/channel/ArtifactTransferException.java
+++ b/core/src/main/java/org/wildfly/channel/ArtifactTransferException.java
@@ -1,0 +1,20 @@
+package org.wildfly.channel;
+
+import java.util.Set;
+
+/**
+ * Thrown in case of an error during downloading of one or more of required artifacts.
+ */
+public class ArtifactTransferException extends UnresolvedMavenArtifactException {
+
+    public ArtifactTransferException(String localizedMessage,
+                                    Throwable cause,
+                                    Set<ArtifactCoordinate> unresolvedArtifacts,
+                                    Set<Repository> attemptedRepositories) {
+        super(localizedMessage, cause, unresolvedArtifacts, attemptedRepositories);
+    }
+
+    public ArtifactTransferException(String message, Set<ArtifactCoordinate> unresolvedArtifacts, Set<Repository> attemptedRepositories) {
+        super(message, unresolvedArtifacts, attemptedRepositories);
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/NoStreamFoundException.java
+++ b/core/src/main/java/org/wildfly/channel/NoStreamFoundException.java
@@ -1,0 +1,20 @@
+package org.wildfly.channel;
+
+import java.util.Set;
+
+/**
+ * Thrown if one or more of required artifacts are not found in specified Channels
+ */
+public class NoStreamFoundException extends UnresolvedMavenArtifactException {
+
+    public NoStreamFoundException(String localizedMessage,
+                                  Throwable cause,
+                                  Set<ArtifactCoordinate> unresolvedArtifacts,
+                                  Set<Repository> attemptedRepositories) {
+        super(localizedMessage, cause, unresolvedArtifacts, attemptedRepositories);
+    }
+
+    public NoStreamFoundException(String message, Set<ArtifactCoordinate> unresolvedArtifacts, Set<Repository> attemptedRepositories) {
+        super(message, unresolvedArtifacts, attemptedRepositories);
+    }
+}

--- a/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
+++ b/core/src/main/java/org/wildfly/channel/UnresolvedMavenArtifactException.java
@@ -18,7 +18,7 @@ package org.wildfly.channel;
 
 import java.util.Set;
 
-public class UnresolvedMavenArtifactException extends RuntimeException {
+public abstract class UnresolvedMavenArtifactException extends RuntimeException {
 
     private final Set<ArtifactCoordinate> unresolvedArtifacts;
     private final Set<Repository> attemptedRepositories;
@@ -32,7 +32,7 @@ public class UnresolvedMavenArtifactException extends RuntimeException {
         this.attemptedRepositories = attemptedRepositories;
     }
 
-    public <E> UnresolvedMavenArtifactException(String message, Set<ArtifactCoordinate> unresolvedArtifacts, Set<Repository> attemptedRepositories) {
+    public UnresolvedMavenArtifactException(String message, Set<ArtifactCoordinate> unresolvedArtifacts, Set<Repository> attemptedRepositories) {
         super(message);
         this.unresolvedArtifacts = unresolvedArtifacts;
         this.attemptedRepositories = attemptedRepositories;

--- a/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
+++ b/core/src/main/java/org/wildfly/channel/spi/MavenVersionsResolver.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ArtifactTransferException;
 import org.wildfly.channel.ChannelMetadataCoordinate;
 import org.wildfly.channel.Repository;
 import org.wildfly.channel.UnresolvedMavenArtifactException;
@@ -57,9 +58,9 @@ public interface MavenVersionsResolver extends Closeable {
     *
     * @return a File representing the resolved Maven artifact.
     *
-    * @throws UnresolvedMavenArtifactException if the artifact can not be resolved.
+    * @throws ArtifactTransferException if the artifact can not be resolved.
     */
-   File resolveArtifact(String groupId, String artifactId, String extension, String classifier, String version) throws UnresolvedMavenArtifactException;
+   File resolveArtifact(String groupId, String artifactId, String extension, String classifier, String version) throws ArtifactTransferException;
 
    /**
     * Resolve a list of maven artifacts based on the full coordinates.
@@ -70,9 +71,9 @@ public interface MavenVersionsResolver extends Closeable {
     *
     * @return a list of File representing the resolved Maven artifact.
     *
-    * @throws UnresolvedMavenArtifactException if any artifacts can not be resolved.
+    * @throws ArtifactTransferException if any artifacts can not be resolved.
     */
-   List<File> resolveArtifacts(List<ArtifactCoordinate> coordinates) throws UnresolvedMavenArtifactException;
+   List<File> resolveArtifacts(List<ArtifactCoordinate> coordinates) throws ArtifactTransferException;
 
    /**
     * Resolve a list of channel metadata artifacts based on the coordinates.
@@ -88,9 +89,9 @@ public interface MavenVersionsResolver extends Closeable {
     *
     * @return a list of URLs to the metadata files
     *
-    * @throws UnresolvedMavenArtifactException if any artifacts can not be resolved.
+    * @throws ArtifactTransferException if any artifacts can not be resolved.
     */
-   List<URL> resolveChannelMetadata(List<? extends ChannelMetadataCoordinate> manifestCoords) throws UnresolvedMavenArtifactException;
+   List<URL> resolveChannelMetadata(List<? extends ChannelMetadataCoordinate> manifestCoords) throws ArtifactTransferException;
 
    /**
     * Returns the {@code <release>} version according to the repositories' Maven metadata. If multiple repositories

--- a/core/src/test/java/org/wildfly/channel/ChannelSessionInitTestCase.java
+++ b/core/src/test/java/org/wildfly/channel/ChannelSessionInitTestCase.java
@@ -122,7 +122,7 @@ public class ChannelSessionInitTestCase {
         mockManifest(resolver, baseManifest, "test.channels:base-manifest:1.0.0");
 
         when(resolver.resolveChannelMetadata(List.of(new ChannelManifestCoordinate("test.channels", "i-dont-exist", "1.0.0"))))
-                .thenThrow(UnresolvedMavenArtifactException.class);
+                .thenThrow(ArtifactTransferException.class);
 
         List<Channel> channels = List.of(new Channel.Builder()
                         .setName("root level requiring channel")


### PR DESCRIPTION
Add `NoStreamFoundException` and `ArtifactTransferException` to the `ChannelSession` and `VersionResolver` API.

`NoStreamFoundException` should be thrown if the channels don't provide a requested artifact, while `ArtifactTransferException` wraps an underlying Maven transfer/resolution error.


This is required to correctly support fallback version resolution when the artifact is not found in channel.
