### PR TITLE
Align versions with Wildfly

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>json-schema-validator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,12 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>2.15.1</version.com.fasterxml.jackson.databind>
-        <version.com.networknt.json-schema-validator>1.0.81</version.com.networknt.json-schema-validator>
+        <version.com.fasterxml.jackson>2.14.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.14.2</version.com.fasterxml.jackson.databind>
+        <version.com.networknt.json-schema-validator>1.0.82</version.com.networknt.json-schema-validator>
         <version.junit5>5.9.3</version.junit5>
-        <version.org.jboss.logging>3.5.0.Final</version.org.jboss.logging>
+        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
+        <version.org.apache.commons.commons-lang3>3.12.0</version.org.apache.commons.commons-lang3>
         <version.release.plugin>3.0.1</version.release.plugin>
         <version.maven.resolver-api>1.9.10</version.maven.resolver-api>
         <version.maven.repository.metadata>3.6.3</version.maven.repository.metadata>
@@ -50,6 +51,11 @@
                 <groupId>com.networknt</groupId>
                 <artifactId>json-schema-validator</artifactId>
                 <version>${version.com.networknt.json-schema-validator}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.org.apache.commons.commons-lang3}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
@jmesnil, @jfdenise - this is to align shared components to the same versions used by Wildfly (and in case of schema-validator - Prospero). Note that it requires downgrade of a few components - alternatively those could be upgraded in Wildfly.