### PR TITLE
Add RetryHandler to retry resolving failed artifacts

### DIFF
--- a/maven-resolver/src/main/java/org/wildfly/channel/maven/RetryHandler.java
+++ b/maven-resolver/src/main/java/org/wildfly/channel/maven/RetryHandler.java
@@ -16,7 +16,10 @@
  */
 package org.wildfly.channel.maven;
 
+import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.transfer.MetadataTransferException;
 import org.jboss.logging.Logger;
 import org.wildfly.channel.ArtifactCoordinate;
 import org.wildfly.channel.ArtifactTransferException;
@@ -25,7 +28,9 @@ import org.wildfly.channel.Repository;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -37,15 +42,18 @@ class RetryHandler {
 
     private final int maxRetries;
     private final long timeout;
+    private final TimeUnit timeUnit;
 
     /**
      *
      * @param maxRetries - maximum times the resolution will be attempted per failing artifact set.
      * @param timeout - timeout between attempts
+     * @param timeUnit - {@code TimeUnit} of the attempt timeout
      */
-    RetryHandler(int maxRetries, long timeout) {
+    RetryHandler(int maxRetries, long timeout, TimeUnit timeUnit) {
         this.maxRetries = maxRetries;
         this.timeout = timeout;
+        this.timeUnit = timeUnit;
     }
 
     /**
@@ -54,42 +62,89 @@ class RetryHandler {
      * @param supplier - performs artifact resolution
      * @param mapper - maps {@code ArtifactResolutionException} to a set of failed {@code ArtifactCoordinate}s
      * @param attemptedRepos - repositories used by {@code supplier}
+     * @throws ArtifactTransferException if the number of retries exceeds {@code maxRetries}
      * @return
      */
-    List<File> attemptResolve(Supplier supplier, Function<ArtifactResolutionException, Set<ArtifactCoordinate>> mapper, Set<Repository> attemptedRepos) {
-        Set<ArtifactCoordinate> lastFailed = Collections.emptySet();
-        int retryCount = 0;
+    List<File> attemptResolve(Supplier supplier,
+                              Function<ArtifactResolutionException, Set<ArtifactCoordinate>> mapper,
+                              Set<Repository> attemptedRepos) {
+        final RetryCounter retryCounter = new RetryCounter(attemptedRepos);
         while (true) {
             try {
                 return supplier.get();
             } catch (ArtifactResolutionException ex) {
                 final Set<ArtifactCoordinate> failed = mapper.apply(ex);
 
-                if (!lastFailed.equals(failed)) {
-                    LOG.debugf("Resetting retry counter. The set of failing artifacts changed");
-                    // reset retry counter
-                    retryCount = 0;
-                }
-
-                if (retryCount++ < maxRetries) {
-                    // retry
-                    lastFailed = failed;
-                    LOG.debugf("Artifact resolution failed - retry #%d", retryCount);
-                    if (timeout > 0) {
-                        try {
-                            LOG.debugf("Pausing resolution retry for %dms", timeout);
-                            Thread.sleep(timeout);
-                        } catch (InterruptedException e) {
-                            throw new ArtifactTransferException(ex.getLocalizedMessage(), e, failed, attemptedRepos);
-                        }
-                    }
-                } else {
-                    LOG.debug("Max retry count reached, failed to resolve artifacts");
-                    throw new ArtifactTransferException(ex.getLocalizedMessage(), ex, failed, attemptedRepos);
-                }
-
+                retryCounter.addRetry(failed, ex);
             }
         }
+    }
+
+    /**
+     * attempts to resolved artifact versions using {@code supplier}. If a MetadataTransferException occurs during resolution, perform retries.
+     *
+     * @param supplier - performs version resolution
+     * @param attemptedRepos - repositories used by {@code supplier}
+     * @throws ArtifactTransferException if the number of retries exceeds {@code maxRetries}
+     * @return
+     */
+    VersionRangeResult attemptResolveMetadata(java.util.function.Supplier<VersionRangeResult> supplier,
+                                       Set<Repository> attemptedRepos) {
+        final RetryCounter retryCounter = new RetryCounter(attemptedRepos);
+
+        while (true) {
+            final VersionRangeResult versionRangeResult = supplier.get();
+
+            final Optional<Exception> transferException = versionRangeResult.getExceptions().stream()
+                    .filter(e -> e.getClass().equals(MetadataTransferException.class))
+                    .findFirst();
+            if (!transferException.isPresent()) {
+                return versionRangeResult;
+            } else {
+                final Artifact artifact = versionRangeResult.getRequest().getArtifact();
+                final Set<ArtifactCoordinate> failed = Set.of(new ArtifactCoordinate(
+                        artifact.getGroupId(), artifact.getArtifactId(), artifact.getExtension(),
+                        artifact.getClassifier(), artifact.getVersion()));
+
+                retryCounter.addRetry(failed, transferException.get());
+            }
+        }
+    }
+
+    private class RetryCounter {
+        private final Set<Repository> attemptedRepos;
+        private int retryCount = 0;
+        private Set<ArtifactCoordinate> lastFailed = Collections.emptySet();
+
+        private RetryCounter(Set<Repository> attemptedRepos) {
+            this.attemptedRepos = attemptedRepos;
+        }
+
+        private void addRetry(Set<ArtifactCoordinate> failed, Exception ex) throws ArtifactTransferException {
+            if (!lastFailed.equals(failed)) {
+                LOG.debugf("Resetting retry counter. The set of failing artifacts changed");
+                // reset retry counter
+                retryCount = 0;
+            }
+
+            if (retryCount++ < maxRetries) {
+                // retry
+                lastFailed = failed;
+                LOG.debugf("Artifact resolution failed - retry #%d", retryCount);
+                if (timeout > 0) {
+                    try {
+                        LOG.debugf("Pausing resolution retry for %dms", timeout);
+                        Thread.sleep(timeUnit.toMillis(timeout));
+                    } catch (InterruptedException e) {
+                        throw new ArtifactTransferException(ex.getLocalizedMessage(), e, failed, attemptedRepos);
+                    }
+                }
+            } else {
+                LOG.debug("Max retry count reached, failed to resolve artifacts");
+                throw new ArtifactTransferException(ex.getLocalizedMessage(), ex, failed, attemptedRepos);
+            }
+        }
+
     }
 
     interface Supplier {

--- a/maven-resolver/src/main/java/org/wildfly/channel/maven/RetryHandler.java
+++ b/maven-resolver/src/main/java/org/wildfly/channel/maven/RetryHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.channel.maven;
+
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.jboss.logging.Logger;
+import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ArtifactTransferException;
+import org.wildfly.channel.Repository;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Retries resolving artifacts. If the set of failing artifacts changes (i.e. some artifacts were resolved), the retry counter
+ * is reset. Optionally uses a timeout between attempts.
+ */
+class RetryHandler {
+    private static final Logger LOG = Logger.getLogger(RetryHandler.class);
+
+    private final int maxRetries;
+    private final long timeout;
+
+    /**
+     *
+     * @param maxRetries - maximum times the resolution will be attempted per failing artifact set.
+     * @param timeout - timeout between attempts
+     */
+    RetryHandler(int maxRetries, long timeout) {
+        this.maxRetries = maxRetries;
+        this.timeout = timeout;
+    }
+
+    /**
+     * attempts to resolved artifact using {@code supplier}. If ArtifactResolutionException is thrown, perform retries.
+     *
+     * @param supplier - performs artifact resolution
+     * @param mapper - maps {@code ArtifactResolutionException} to a set of failed {@code ArtifactCoordinate}s
+     * @param attemptedRepos - repositories used by {@code supplier}
+     * @return
+     */
+    List<File> attemptResolve(Supplier supplier, Function<ArtifactResolutionException, Set<ArtifactCoordinate>> mapper, Set<Repository> attemptedRepos) {
+        Set<ArtifactCoordinate> lastFailed = Collections.emptySet();
+        int retryCount = 0;
+        while (true) {
+            try {
+                return supplier.get();
+            } catch (ArtifactResolutionException ex) {
+                final Set<ArtifactCoordinate> failed = mapper.apply(ex);
+
+                if (!lastFailed.equals(failed)) {
+                    LOG.debugf("Resetting retry counter. The set of failing artifacts changed");
+                    // reset retry counter
+                    retryCount = 0;
+                }
+
+                if (retryCount++ < maxRetries) {
+                    // retry
+                    lastFailed = failed;
+                    LOG.debugf("Artifact resolution failed - retry #%d", retryCount);
+                    if (timeout > 0) {
+                        try {
+                            LOG.debugf("Pausing resolution retry for %dms", timeout);
+                            Thread.sleep(timeout);
+                        } catch (InterruptedException e) {
+                            throw new ArtifactTransferException(ex.getLocalizedMessage(), e, failed, attemptedRepos);
+                        }
+                    }
+                } else {
+                    LOG.debug("Max retry count reached, failed to resolve artifacts");
+                    throw new ArtifactTransferException(ex.getLocalizedMessage(), ex, failed, attemptedRepos);
+                }
+
+            }
+        }
+    }
+
+    interface Supplier {
+        List<File> get() throws ArtifactResolutionException;
+    }
+}

--- a/maven-resolver/src/test/java/org/wildfly/channel/maven/RetryHandlerTest.java
+++ b/maven-resolver/src/test/java/org/wildfly/channel/maven/RetryHandlerTest.java
@@ -30,6 +30,7 @@ import org.wildfly.channel.ArtifactTransferException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +41,7 @@ class RetryHandlerTest {
     private RetryHandler resolver;
     @BeforeEach
     public void setUp() {
-        resolver = new RetryHandler(5, 0);
+        resolver = new RetryHandler(5, 0, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/maven-resolver/src/test/java/org/wildfly/channel/maven/RetryHandlerTest.java
+++ b/maven-resolver/src/test/java/org/wildfly/channel/maven/RetryHandlerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.channel.maven;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ArtifactTransferException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RetryHandlerTest {
+
+    private RetryHandler resolver;
+    @BeforeEach
+    public void setUp() {
+        resolver = new RetryHandler(5, 0);
+    }
+
+    @Test
+    public void testResolveRetriedSupplier() throws Exception {
+        final ArtifactResult res = new ArtifactResult(new ArtifactRequest());
+        final ArtifactCoordinate coord = Mockito.mock(ArtifactCoordinate.class);
+
+        AtomicInteger counter = new AtomicInteger(0);
+        resolver.attemptResolve(()-> {
+            if (counter.getAndIncrement() < 1) {
+                throw new ArtifactResolutionException(List.of(res));
+            }
+            return Collections.emptyList();
+        }, (ex)-> Set.of(coord), Collections.emptySet());
+
+        assertEquals(2, counter.get());
+    }
+
+    @Test
+    public void failAfterRetriesExceeded() throws Exception {
+        final ArtifactResult res = new ArtifactResult(new ArtifactRequest());
+        final ArtifactCoordinate coord = Mockito.mock(ArtifactCoordinate.class);
+
+        AtomicInteger counter = new AtomicInteger(0);
+        assertThrows(ArtifactTransferException.class,
+                ()->resolver.attemptResolve(()-> {
+                    counter.getAndIncrement();
+                    throw new ArtifactResolutionException(List.of(res));
+        }, (ex)-> Set.of(coord), Collections.emptySet()));
+
+        assertEquals(6, counter.get());
+    }
+
+    @Test
+    public void resetsCounterAfterArtifactResolvedExceeded() throws Exception {
+        final Artifact artifact1 = new DefaultArtifact("org.test", "one", "jar" ,"1.2.3");
+        final Artifact artifact2 = new DefaultArtifact("org.test", "two", "jar" ,"1.2.3");
+        final ArtifactResult res1 = new ArtifactResult(new ArtifactRequest(artifact1, null, null));
+        final ArtifactResult res2 = new ArtifactResult(new ArtifactRequest(artifact2, null, null));
+        final ArtifactCoordinate coord = Mockito.mock(ArtifactCoordinate.class);
+
+        AtomicInteger counter = new AtomicInteger(0);
+        resolver.attemptResolve(() -> {
+            // simulate first artifact being resolved after initial 4 reties
+            // but second artifact requiring further 3 retries
+            if (counter.getAndIncrement() < 4) {
+                throw new ArtifactResolutionException(List.of(res1, res2));
+            } else if (counter.getAndIncrement() < 7) {
+                throw new ArtifactResolutionException(List.of(res2));
+            } else {
+                return Collections.emptyList();
+            }
+        }, (ex) -> Set.of(coord), Collections.emptySet());
+
+        // in total retry count exceeds the allowed retries (as it was applied to different artifacts)
+        assertEquals(8, counter.get());
+    }
+}


### PR DESCRIPTION
In order to help with intermittent artifact transfer failures, retry the failing artifacts transfer.

If the max-retries is used and the same artifacts are failing, throw the initial exception.

Note the set of failing artifacts can change - when resolving a large set of artifacts, not all artifacts are attempted at the same time. The max-retries are applied per failing set of artifacts to allow for situation where different artifacts fail but are resolved on retry.

The max-retries and optional timeout can be configured with system properties.
