### PR TITLE
Correct field names in generated channel file

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -118,6 +118,7 @@ public class Channel {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("blocklist")
     public BlocklistCoordinate getBlocklistCoordinate() {
         return blocklistCoordinate;
     }
@@ -129,6 +130,7 @@ public class Channel {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("resolve-if-no-stream")
     public NoStreamStrategy getNoStreamStrategy() {
         return noStreamStrategy;
     }


### PR DESCRIPTION
The channel file generated using the ChannelMapper has `noStreamStrategy` field instead of `resolve-if-no-stream`