### PR TITLE
Add ChannelManifest.Builder

### DIFF
--- a/core/src/main/java/org/wildfly/channel/Channel.java
+++ b/core/src/main/java/org/wildfly/channel/Channel.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import java.util.ArrayList;
+import java.util.Objects;
+
 import static java.util.Collections.emptyList;
 
 public class Channel {
@@ -169,6 +171,19 @@ public class Channel {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Channel channel = (Channel) o;
+        return Objects.equals(schemaVersion, channel.schemaVersion) && Objects.equals(name, channel.name) && Objects.equals(description, channel.description) && Objects.equals(vendor, channel.vendor) && Objects.equals(repositories, channel.repositories) && Objects.equals(blocklistCoordinate, channel.blocklistCoordinate) && Objects.equals(manifestCoordinate, channel.manifestCoordinate) && noStreamStrategy == channel.noStreamStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemaVersion, name, description, vendor, repositories, blocklistCoordinate, manifestCoordinate, noStreamStrategy);
+    }
+
     /**
      * Builder for channel class
      */
@@ -180,6 +195,19 @@ public class Channel {
         private NoStreamStrategy strategy;
         private String description;
         private Vendor vendor;
+
+        public Builder() {
+        }
+
+        public Builder(Channel from) {
+            this.name = from.getName();
+            this.repositories = new ArrayList<>(from.getRepositories());
+            this.manifestCoordinate = from.getManifestCoordinate();
+            this.blocklistCoordinate = from.getBlocklistCoordinate();
+            this.strategy = from.getNoStreamStrategy();
+            this.description = from.getDescription();
+            this.vendor = from.getVendor();
+        }
 
         public Channel build() {
             return new Channel(name, description, vendor, repositories, manifestCoordinate, blocklistCoordinate, strategy);
@@ -195,6 +223,11 @@ public class Channel {
             return this;
         }
 
+        public Builder setRepositories(List<Repository> repositories) {
+            this.repositories = repositories;
+            return this;
+        }
+
         public Builder setVendor(Vendor vendor) {
             this.vendor = vendor;
             return this;
@@ -207,6 +240,11 @@ public class Channel {
 
         public Builder setManifestCoordinate(String groupId, String artifactId, String version) {
             this.manifestCoordinate = new ChannelManifestCoordinate(groupId, artifactId, version);
+            return this;
+        }
+
+        public Builder setManifestCoordinate(String groupId, String artifactId) {
+            this.manifestCoordinate = new ChannelManifestCoordinate(groupId, artifactId);
             return this;
         }
 
@@ -226,6 +264,11 @@ public class Channel {
             } else {
                 this.blocklistCoordinate = new BlocklistCoordinate(groupId, artifactId, version);
             }
+            return this;
+        }
+
+        public Builder setBlocklistCoordinate(BlocklistCoordinate blocklistCoordinate) {
+            this.blocklistCoordinate = blocklistCoordinate;
             return this;
         }
 

--- a/core/src/main/java/org/wildfly/channel/ChannelManifest.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifest.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -191,5 +193,72 @@ public class ChannelManifest {
                 ", streams=" + streams +
                 ", manifestRequirements=" + manifestRequirements +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChannelManifest that = (ChannelManifest) o;
+        return Objects.equals(schemaVersion, that.schemaVersion) && Objects.equals(name, that.name) && Objects.equals(id, that.id) && Objects.equals(description, that.description) && Objects.equals(streams, that.streams) && Objects.equals(manifestRequirements, that.manifestRequirements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schemaVersion, name, id, description, streams, manifestRequirements);
+    }
+
+    public static class Builder {
+        private String schemaVersion;
+        private String name;
+        private String id;
+        private String description;
+        private List<Stream> streams;
+        private List<ManifestRequirement> manifestRequirements;
+
+        public ChannelManifest build() {
+            return new ChannelManifest(
+                    schemaVersion,
+                    id,
+                    description,
+                    manifestRequirements,
+                    streams);
+        }
+
+        public Builder setSchemaVersion(String schemaVersion) {
+            this.schemaVersion = schemaVersion;
+            return this;
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder addStreams(Stream... stream) {
+            if (this.streams == null) {
+                this.streams = new ArrayList<>();
+            }
+            this.streams.addAll(Arrays.asList(stream));
+            return this;
+        }
+
+        public Builder addManifestRequirements(ManifestRequirement... manifestRequirements) {
+            if (this.manifestRequirements == null) {
+                this.manifestRequirements = new ArrayList<>();
+            }
+            this.manifestRequirements.addAll(Arrays.asList(manifestRequirements));
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Adding Builder for ChannelManifest to make it easier to create them especially in tests.
Adding missing builder options for Channel and missing equals/toHash methods in Builder and ChannelManifest
