### PR TITLE
Add logical-version field version to the manifest schema

### DIFF
--- a/core/src/main/java/org/wildfly/channel/ChannelManifest.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifest.java
@@ -60,6 +60,12 @@ public class ChannelManifest {
     private final String id;
 
     /**
+     * Optional human-readable version of the manifest.
+     * Alphanumeric version of manifest. Note, this version does *not* need to align with the Maven coordinate version.
+     */
+    private final String logicalVersion;
+
+    /**
      * Optional description of the manifest. It can use multiple lines.
      */
     private final String description;
@@ -86,6 +92,7 @@ public class ChannelManifest {
         this(ChannelManifestMapper.CURRENT_SCHEMA_VERSION,
                 name,
                 id,
+                null,
                 description,
                 Collections.emptyList(),
                 streams);
@@ -98,12 +105,14 @@ public class ChannelManifest {
      */
     public ChannelManifest(String name,
                            String id,
+                           String logicalVersion,
                            String description,
                            Collection<ManifestRequirement> manifestRequirements,
                            Collection<Stream> streams) {
         this(ChannelManifestMapper.CURRENT_SCHEMA_VERSION,
                 name,
                 id,
+                logicalVersion,
                 description,
                 manifestRequirements,
                 streams);
@@ -122,12 +131,14 @@ public class ChannelManifest {
     public ChannelManifest(@JsonProperty(value = "schemaVersion", required = true) String schemaVersion,
                            @JsonProperty(value = "name") String name,
                            @JsonProperty(value = "id") String id,
+                           @JsonProperty(value = "logical-version") String logicalVersion,
                            @JsonProperty(value = "description") String description,
                            @JsonProperty(value = "requires") Collection<ManifestRequirement> manifestRequirements,
                            @JsonProperty(value = "streams") Collection<Stream> streams) {
         this.schemaVersion = schemaVersion;
         this.name = name;
         this.id = id;
+        this.logicalVersion = logicalVersion;
         this.description = description;
         this.manifestRequirements = new ArrayList<>();
         if (manifestRequirements != null) {
@@ -152,6 +163,11 @@ public class ChannelManifest {
     @JsonInclude(NON_NULL)
     public String getId() {
         return id;
+    }
+
+    @JsonInclude(NON_NULL)
+    public String getLogicalVersion() {
+        return logicalVersion;
     }
 
     @JsonInclude(NON_NULL)

--- a/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
+++ b/core/src/main/java/org/wildfly/channel/ChannelManifestMapper.java
@@ -51,9 +51,11 @@ import static java.util.Objects.requireNonNull;
 public class ChannelManifestMapper {
 
     public static final String SCHEMA_VERSION_1_0_0 = "1.0.0";
-    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_0_0;
+    public static final String SCHEMA_VERSION_1_1_0 = "1.1.0";
+    public static final String CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1_1_0;
 
     private static final String SCHEMA_1_0_0_FILE = "org/wildfly/manifest/v1.0.0/schema.json";
+    private static final String SCHEMA_1_1_0_FILE = "org/wildfly/manifest/v1.1.0/schema.json";
     private static final YAMLFactory YAML_FACTORY = new YAMLFactory()
             .configure(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(YAML_FACTORY)
@@ -64,6 +66,7 @@ public class ChannelManifestMapper {
 
     static {
         SCHEMAS.put(SCHEMA_VERSION_1_0_0, SCHEMA_FACTORY.getSchema(ChannelManifestMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_0_0_FILE)));
+        SCHEMAS.put(SCHEMA_VERSION_1_1_0, SCHEMA_FACTORY.getSchema(ChannelManifestMapper.class.getClassLoader().getResourceAsStream(SCHEMA_1_1_0_FILE)));
     }
 
     private static JsonSchema getSchema(JsonNode node) {

--- a/core/src/main/resources/org/wildfly/manifest/v1.1.0/schema.json
+++ b/core/src/main/resources/org/wildfly/manifest/v1.1.0/schema.json
@@ -1,0 +1,96 @@
+{
+  "$id": "https://wildfly.org/manifests/v1.0.0/schema.json",
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {
+      "description": "The version of the schema defining a manifest resource.",
+      "type": "string",
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$"
+    },
+    "id": {
+      "description": "ID of the manifest. Used to resolved inter-channel requirements."
+    },
+    "name": {
+      "description": "Name of the manifest. This is a one-line human-readable description of the manifest",
+      "type": "string"
+    },
+    "description": {
+      "description": "Description of the manifest. This is a multi-lines human-readable description of the manifest",
+      "type": "string"
+    },
+    "logical-version": {
+      "description": "Version of the manifest. This is a short, one-line, human-readable version of the manifest. Note it is not necessary the same as manifest's Maven version.",
+      "type": "string"
+    },
+    "requires": {
+      "description": "Manifests that are required by this manifest.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "minItems": 1,
+        "properties": {
+          "id": {
+            "description": "ID of the required manifest.",
+            "type": "string"
+          },
+          "maven": {
+            "type": "object",
+            "properties": {
+              "groupId": {
+                "description": "GroupID Maven coordinate of the required manifest",
+                "type": "string"
+              },
+              "artifactId": {
+                "description": "ArtifactID Maven coordinate of the required manifest",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version Maven coordinate of the required manifest",
+                "type": "string"
+              }
+            },
+            "required": ["groupId", "artifactId"]
+          }
+        },
+        "required": ["id"]
+      }
+    },
+    "streams":{
+      "description": "Streams of components that are provided by this channel",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "groupId": {
+            "description": "GroupId of the stream. It must be a valid groupId (corresponding to a G of a Maven GAV)",
+            "type": "string"
+          },
+          "artifactId": {
+            "description": "ArtifactId of the stream. It must be either a valid artifactId (corresponding to a A of a Maven GAV) or the * character to represent any artifactId",
+            "type": "string"
+          },
+          "version" : {
+            "description": "Version of the stream. This must be a single version. Only one of version, versionPattern must be set.",
+            "type": "string"
+          },
+          "versionPattern" : {
+            "description": "VersionPattern of the stream. This is a regular expression that matches any version from this stream. Only one of version, versionPattern must be set.",
+            "type": "string"
+          }
+        },
+        "required": ["groupId", "artifactId"],
+        "oneOf": [
+          {
+            "required": ["version"]
+          },
+          {
+            "required": ["versionPattern"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/wildfly/channel/ManifestBuilder.java
+++ b/core/src/test/java/org/wildfly/channel/ManifestBuilder.java
@@ -22,15 +22,21 @@ import java.util.List;
 class ManifestBuilder {
 
     private String id;
+    private String logicalVersion;
     private List<ManifestRequirement> requirements = new ArrayList<>();
     private List<Stream> streams = new ArrayList<>();
 
     ChannelManifest build() {
-        return new ChannelManifest(null, id, null, requirements, streams);
+        return new ChannelManifest(null, id, logicalVersion, null, requirements, streams);
     }
 
     ManifestBuilder setId(String id) {
         this.id = id;
+        return this;
+    }
+
+    public ManifestBuilder setLogicalVersion(String logicalVersion) {
+        this.logicalVersion = logicalVersion;
         return this;
     }
 

--- a/doc/spec.adoc
+++ b/doc/spec.adoc
@@ -6,7 +6,7 @@
 [cols="1,1"]
 |===
 | Channel schema Version | 2.0.0
-| Manifest schema Version | 1.0.0
+| Manifest schema Version | 1.1.0
 | Blocklist schema Version | 1.0.0
 |===
 
@@ -83,6 +83,7 @@ A Channel Manifest is composed of following fields:
 * An optional `name` that is a human-readable one-line description of the channel (`manifest for WildFly 27`)
 * An optional `id` element that is used to identify channel.
 * An optional `description` that provides human-readable description of the channel
+* An optional `logical-version` that provides a human-readable short description of the version of the manifest. Note this may, but doesn't need to correspond to the Maven version of the artifact (from Manifest schema 1.1.0).
 * A collection of `requires`. Each element of that list corresponds to another channel that is required to provision components from this channel.
 This field can be used for layered products to enforce their dependencies so that the installation only need to update the top level channel to get updates from all required channels.
 Each element is composed of:
@@ -242,4 +243,3 @@ During artifact version resolution, a stream matching artifact GA is located in 
 ### Version 1.0.0
 
 * Initial release of the Channel specification
-


### PR DESCRIPTION
Add an optional `logical-version` field to the manifest schema. The new field can be used to provide a short human-readable information about the version of the manifest
