### PR TITLE
Update upload-artifact GH action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
     - name: coverage
       run: mvn -B verify --file pom.xml -Pcoverage
     - name: upload report
-      uses: 'actions/upload-artifact@v2'
+      uses: 'actions/upload-artifact@v4'
       with:
-        name: jacoco
+        name: "jacoco-${{ matrix.jdk }}"
         path: coverage/target/site/jacoco-aggregate


### PR DESCRIPTION
@jmesnil the upload-action v2 has been deprecated and is causing test failures, so updating it to v4.