### PR TITLE
Upgrade maven-repository-metadata to 3.9.9, maven-resolver-api to 1.9.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         <version.org.wiremock>3.9.1</version.org.wiremock>
         <version.org.assertj>3.26.3</version.org.assertj>
         <version.release.plugin>3.1.1</version.release.plugin>
-        <version.maven.resolver-api>1.9.20</version.maven.resolver-api>
-        <version.maven.repository.metadata>3.6.3</version.maven.repository.metadata>
+        <version.maven.resolver-api>1.9.22</version.maven.resolver-api>
+        <version.maven.repository.metadata>3.9.9</version.maven.repository.metadata>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Currently these upgrades don't require any code changes, but as both prospero and wildfly/eap-maven-plugin are using maven 3.9.x, it would provide us with more confidence to see wildfly-channel on this version too. WDYT @jmesnil ?

(The resolver upgrade is collateral, upgrading to the latest version, can be left out.)